### PR TITLE
Add how to call pre-process script (addresses #14).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,5 +32,7 @@ before_script:
   - if [ "${USE_CATKIN_MAKE}" == "true" ] ;then sed -i 's@catkin run_tests --no-deps --limit-status-rate 0.001@catkin_make run_tests@' $CI_DIR/travis.sh; fi
   - if [ "${USE_CATKIN_MAKE}" == "true" ] ;then export CATKIN_PARALLEL_JOBS="--no-color" ; fi
 script:
+  - source $CI_DIR/pre-process.sh
   - source $CI_DIR/travis.sh
   - if [ "${AFTER_INSTALL}" != "" ] ; then sudo apt-get install -f ${AFTER_INSTALL}; fi
+  - source $CI_DIR/post-process.sh

--- a/README.rst
+++ b/README.rst
@@ -234,6 +234,24 @@ The jobs that run Prerelease Test may usually take longer than the tests defined
 
 Then open a pull request using this branch against the branch that the change is subject to be merged. You do not want to actually merge this branch no matter what the Travis result is. This branch is solely for Prerelease Test purpose.
 
+Run pre-install custom commands
+-----------------------------------------
+
+You may want to add custom steps prior to the setup defined in `./travis.sh <./travis.sh>`_. Example:
+
+* A device driver package X in your repository or in your repository's dependency requires a prorietary library installed. This library is publicly available, but not via apt or any package management system and thus the only way you can install it is in a classic way (unzip, run installer etc.) (`More discussion <<https://github.com/ros-industrial/industrial_ci/issues/14>`_).
+
+In this case, add `source`d scripts before `travis.sh` gets called (see below for an example). 
+
+::
+
+  script: 
+    - source ./your_custom_PREprocess.sh
+    - source .ci_config/travis.sh
+    - source ./your_custom_POSTprocess.sh
+
+In the above case, in both `.ci_config/travis.sh` and `your_custom_POSTprocess.sh` the environment is kept from previous script(s), so whatever is done in previous scripts remains. 
+
 For maintainers of industrial_ci repository
 ================================================
 

--- a/post-process.sh
+++ b/post-process.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2015, Isaac I. Y. Saito
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#       * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#       * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#       * Neither the name of the Isaac I. Y. Saito, nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+set -x
+
+# Users can define whatever commands below as a post-process.
+echo "post_travis.sh BEGIN";
+echo $PATH;
+# Here we demonstrate a tool/game that is previously installed in pre-process is still available in this separate script.
+/usr/games/sl;  # For some reason, relative path becomes error on Travis.
+echo "post_travis.sh END";

--- a/pre-process.sh
+++ b/pre-process.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2015, Isaac I. Y. Saito
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#       * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#       * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#       * Neither the name of the Isaac I. Y. Saito, nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+set -x
+
+# Users can define whatever commands below as a pre-process.
+echo "custom_setup.sh BEGIN";
+sudo apt-get update
+sudo apt-get install -y -q -qq sl
+echo $PATH;
+# Here we install a tool/game that is going to be run in post-process, to show that the environment is kept over multiple scripts.
+/usr/games/sl;  # For some reason, relative path becomes error on Travis.
+echo "custom_setup.sh END";


### PR DESCRIPTION
To the question #14 I found that we actually don't need additional implementation. As added to the readme in this PR, we can simply call pre-processing script(s).

This PR also adds tests for the proposed concept; install a [`sl` command](http://unix.stackexchange.com/a/341/14968) in the pre-process, and calling it in the post-process is successful as you see [in this output](https://travis-ci.org/130s/industrial_ci/jobs/101186280#L3309) (because of Travis' time-elapsed view, the output looks broken but we can tell the program is installed).

Lastly, only as a reference, I've experimented another way to address #14; See https://github.com/130s/industrial_ci/pull/5 where `travis.sh` is modified to accept custom script if specified. I found it redundant and overkill.