### PR TITLE
Add option to not test 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ env:
     - ROS_DISTRO=indigo BUILDER='not-compile'
     - ROS_DISTRO=indigo BUILDER='not-compile' TRAVIS_REPO_SLUG=ros-industrial/industrial_ci
     - ROS_DISTRO=indigo BUILDER='not-compile' TRAVIS_REPO_SLUG=ros-industrial/industrial_ci TRAVIS_BRANCH=master TRAVIS_COMMIT=''  TRAVIS_PULL_REQUEST=''
+    - ROS_DISTRO=indigo NOT_TEST_BUILD='true'
+    - ROS_DISTRO=indigo NOT_TEST_INSTALL='true'
 matrix:
   allow_failures:
     - env: ROS_DISTRO=jade BUILDER='not-compile'

--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,8 @@ Note that some of these currently tied only to a single option, but we still lea
 * `BUILD_PKGS` (default: not set): `PKGS_DOWNSTREAM` will be filled with packages specified with this. Also these packages are to be built when `NOT_TEST_INSTALL` is set.
 * `BUILDER` (default: catkin): Currently only `catkin` is implemented (and with that `catkin_tools` is used instead of `catkin_make`. See `this discussion <https://github.com/ros-industrial/industrial_ci/issues/3>`_).
 * `CI_PARENT_DIR` (default: .ci_config): (NOT recommended to specify) This is the folder name that is used in downstream repositories in order to point to this repo.
-* `NOT_TEST_INSTALL` (default: not set): If you do NOT want to test `install` space, set this as true.
+* `NOT_TEST_BUILD` (default: not set): If true, tests in build space won't be run.
+* `NOT_TEST_INSTALL` (default: not set): If true, tests in `install` space won't be run.
 * `PKGS_DOWNSTREAM` (default: explained): Packages in downstream to be tested. By default, `TARGET_PKGS` is used if set, if not then `BUILD_PKGS` is used.
 * `ROS_PARALLEL_JOBS` (default: -j8): Maximum number of packages which could be built in parallel. See for more detail `documentation of catkin_tools <https://catkin-tools.readthedocs.org/en/latest/verbs/catkin_build.html#full-command-line-interface>`_ that this env variable is passed to internally.
 * `ROS_PARALLEL_TEST_JOBS` (default: not set): Maximum number of packages which could be examined in parallel during the test run. If not set it's filled by `ROS_PARALLEL_JOBS`.

--- a/travis.sh
+++ b/travis.sh
@@ -197,23 +197,26 @@ if [ "${PKGS_DOWNSTREAM// }" == "" ]; then export PKGS_DOWNSTREAM=$( [ "${BUILD_
 if [ "$BUILDER" == catkin ]; then catkin build -i -v --summarize  --no-status $BUILD_PKGS $CATKIN_PARALLEL_JOBS --make-args $ROS_PARALLEL_JOBS            ; fi
 
 travis_time_end  # catkin_build
-travis_time_start catkin_run_tests
 
-# Patches for rostest that are only available in newer codes.
-# Some are already available via DEBs so that patches for them are not needed, but because EOLed distros (e.g. Hydro) where those patches are not released into may be still tested, all known patches are applied here.
-(cd /opt/ros/$ROS_DISTRO/lib/python2.7/dist-packages; wget --no-check-certificate https://patch-diff.githubusercontent.com/raw/ros/ros_comm/pull/611.diff -O - | sudo patch -f -p4 || echo "ok" )
-if [ "$ROS_DISTRO" == "hydro" ]; then
-    (cd /opt/ros/$ROS_DISTRO/lib/python2.7/dist-packages; wget --no-check-certificate https://patch-diff.githubusercontent.com/raw/ros/ros/pull/82.diff -O - | sudo patch -p4)
-    (cd /opt/ros/$ROS_DISTRO/share; wget --no-check-certificate https://patch-diff.githubusercontent.com/raw/ros/ros_comm/pull/611.diff -O - | sed s@.cmake.em@.cmake@ | sed 's@/${PROJECT_NAME}@@' | sed 's@ DEPENDENCIES ${_rostest_DEPENDENCIES})@)@' | sudo patch -f -p2 || echo "ok")
+if [ "$NOT_TEST_BUILD" != "true" ]; then
+    travis_time_start catkin_run_tests
+    
+    # Patches for rostest that are only available in newer codes.
+    # Some are already available via DEBs so that patches for them are not needed, but because EOLed distros (e.g. Hydro) where those patches are not released into may be still tested, all known patches are applied here.
+    (cd /opt/ros/$ROS_DISTRO/lib/python2.7/dist-packages; wget --no-check-certificate https://patch-diff.githubusercontent.com/raw/ros/ros_comm/pull/611.diff -O - | sudo patch -f -p4 || echo "ok" )
+    if [ "$ROS_DISTRO" == "hydro" ]; then
+        (cd /opt/ros/$ROS_DISTRO/lib/python2.7/dist-packages; wget --no-check-certificate https://patch-diff.githubusercontent.com/raw/ros/ros/pull/82.diff -O - | sudo patch -p4)
+        (cd /opt/ros/$ROS_DISTRO/share; wget --no-check-certificate https://patch-diff.githubusercontent.com/raw/ros/ros_comm/pull/611.diff -O - | sed s@.cmake.em@.cmake@ | sed 's@/${PROJECT_NAME}@@' | sed 's@ DEPENDENCIES ${_rostest_DEPENDENCIES})@)@' | sudo patch -f -p2 || echo "ok")
+    fi
+    
+    if [ "$BUILDER" == catkin ]; then
+        source devel/setup.bash ; rospack profile # force to update ROS_PACKAGE_PATH for rostest
+        catkin run_tests -iv --no-deps --no-status $PKGS_DOWNSTREAM $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS --
+        catkin_test_results build || error
+    fi
+    
+    travis_time_end  # catkin_run_tests
 fi
-
-if [ "$BUILDER" == catkin ]; then
-    source devel/setup.bash ; rospack profile # force to update ROS_PACKAGE_PATH for rostest
-    catkin run_tests -iv --no-deps --no-status $PKGS_DOWNSTREAM $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS --
-    catkin_test_results build || error
-fi
-
-travis_time_end  # catkin_run_tests
 
 if [ "$NOT_TEST_INSTALL" != "true" ]; then
 


### PR DESCRIPTION
There might a case where you don't want to run the tests, neither from build nor install spaces.

Example; device driver packages where emulation is not yet available, but you still want to check other things defined in the CI config (build etc.)

Since `NOT_TEST_INSTALL` is already implemented, in this PR I'm adding `NOT_TEST_BUILD`.