### PR TITLE
Move a patch that becomes available via DEB to older ROS distro only section

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -203,8 +203,8 @@ if [ "$NOT_TEST_BUILD" != "true" ]; then
     
     # Patches for rostest that are only available in newer codes.
     # Some are already available via DEBs so that patches for them are not needed, but because EOLed distros (e.g. Hydro) where those patches are not released into may be still tested, all known patches are applied here.
-    (cd /opt/ros/$ROS_DISTRO/lib/python2.7/dist-packages; wget --no-check-certificate https://patch-diff.githubusercontent.com/raw/ros/ros_comm/pull/611.diff -O - | sudo patch -f -p4 || echo "ok" )
     if [ "$ROS_DISTRO" == "hydro" ]; then
+        (cd /opt/ros/$ROS_DISTRO/lib/python2.7/dist-packages; wget --no-check-certificate https://patch-diff.githubusercontent.com/raw/ros/ros_comm/pull/611.diff -O - | sudo patch -f -p4 || echo "ok" )
         (cd /opt/ros/$ROS_DISTRO/lib/python2.7/dist-packages; wget --no-check-certificate https://patch-diff.githubusercontent.com/raw/ros/ros/pull/82.diff -O - | sudo patch -p4)
         (cd /opt/ros/$ROS_DISTRO/share; wget --no-check-certificate https://patch-diff.githubusercontent.com/raw/ros/ros_comm/pull/611.diff -O - | sed s@.cmake.em@.cmake@ | sed 's@/${PROJECT_NAME}@@' | sed 's@ DEPENDENCIES ${_rostest_DEPENDENCIES})@)@' | sudo patch -f -p2 || echo "ok")
     fi


### PR DESCRIPTION
to keep the code cleaner. Looks like the patch in `rostest` in question is already included in [deb version of 1.11.16 that's already out there](http://repositories.ros.org/status_page/ros_indigo_default.html?q=rostest).

This PR will resolve a patch error like https://github.com/ros-industrial/staubli/pull/20#issuecomment-18076221.