### PR TITLE
Workaround for rospack 2.3.0 (fix #26).

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -64,6 +64,9 @@ function error {
     exit 1
 }
 
+CHARCOLOR_YELLOW='\033[1;33m'
+CHARCOLOR_NOCOLOR='\033[0m'
+
 BUILDER=catkin
 ROSWS=wstool
 CI_PARENT_DIR=.ci_config  # This is the folder name that is used in downstream repositories in order to point to this repo.
@@ -230,7 +233,8 @@ if [ "$NOT_TEST_INSTALL" != "true" ]; then
         catkin build -i -v --summarize --no-status $BUILD_PKGS $CATKIN_PARALLEL_JOBS --make-args $ROS_PARALLEL_JOBS
         source install/setup.bash
         rospack profile
-        rospack plugins --attrib=plugin nodelet
+        # 
+        rospack plugins --attrib=plugin nodelet || echo -e "${CHARCOLOR_YELLOW}No nodelet plugin found.${CHARCOLOR_NOCOLOR} If any of the software in your repository does not utilize nodelet, ignore this. ${CHARCOLOR_YELLOW}But if your software depends on nodelet but you're seeing this warning, something is wrong.${CHARCOLOR_NOCOLOR}"
     fi
 
     travis_time_end  # catkin_install_build


### PR DESCRIPTION
https://github.com/ros-industrial/industrial_ci/compare/master...130s:fix/rospackplugins#diff-f9a62833538ab14fff849c2be16ab986L233

```
rospack plugins --attrib=plugin nodelet
```

This line is nice to check if the nodelet plugin is properly configured or not when the software tested contains at least one plugin. But this particular line is so agressive that even repositories where no nodelet is used turns to failure, with `rospack` version 2.3.0.

So I'm kind of relaxing this line of test by only printing warning message regardless of the check result, without ending the entire build on Travis.

I'm now running test using a downstream repo, [my forked ros_canopen](https://github.com/130s/ros_canopen/pull/1).

(I've already implemented a feature to specify downstream repos utilizing `.rosinstall`, but it's in https://github.com/ros-industrial/industrial_ci/pull/23 and even the specific commit is mixed with irrelevant change (my bad) that's why I couldn't use .rosinstall in this PR.)
