### PR TITLE
Update travis.sh for new catkin 0.4.0 version

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -225,7 +225,7 @@ if [ "$NOT_TEST_INSTALL" != "true" ]; then
 
     # Test if the packages in the downstream repo build.
     if [ "$BUILDER" == catkin ]; then
-        catkin clean -a
+        catkin clean -y
         catkin config --install
         catkin build -i -v --summarize --no-status $BUILD_PKGS $CATKIN_PARALLEL_JOBS --make-args $ROS_PARALLEL_JOBS
         source install/setup.bash


### PR DESCRIPTION
`catkin_tools` 0.4.0 has been released and `catkin clean -a` has been replaced with `catkin clean -y`

Build log example:
https://travis-ci.org/InstitutMaupertuis/simple_rviz_plugin/jobs/124107265#L4341