### PR TITLE
Fix apt-get quiet option

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -91,14 +91,14 @@ sudo -E sh -c 'echo "deb $ROS_REPOSITORY_PATH `lsb_release -cs` main" > /etc/apt
 wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
 lsb_release -a
 sudo apt-get update
-sudo apt-get install -y -q -qq python-catkin-tools python-rosdep python-wstool ros-$ROS_DISTRO-rosbash ros-$ROS_DISTRO-rospack
+sudo apt-get -qq install -y python-catkin-tools python-rosdep python-wstool ros-$ROS_DISTRO-rosbash ros-$ROS_DISTRO-rospack
 # If more DEBs needed during preparation, define ADDITIONAL_DEBS variable where you list the name of DEB(S, delimitted by whitespace)
 if [ "$ADDITIONAL_DEBS" ]; then sudo apt-get install -q -qq -y $ADDITIONAL_DEBS;  fi
 # MongoDB hack - I don't fully understand this but its for moveit_warehouse
 dpkg -s mongodb || echo "ok"; export HAVE_MONGO_DB=$?
 if [ $HAVE_MONGO_DB == 0 ]; then
-    sudo apt-get remove -q -qq -y mongodb mongodb-10gen || echo "ok"
-    sudo apt-get install -q -qq -y mongodb-clients mongodb-server -o Dpkg::Options::="--force-confdef" || echo "ok"
+    sudo apt-get -qq remove -y mongodb mongodb-10gen || echo "ok"
+    sudo apt-get -qq install -y mongodb-clients mongodb-server -o Dpkg::Options::="--force-confdef" || echo "ok"
 fi
 
 travis_time_end  # setup_ros
@@ -116,7 +116,7 @@ travis_time_start setup_catkin
 
 ## BEGIN: travis' before_install: # Use this to prepare the system to install prerequisites or dependencies ##
 # https://github.com/ros/ros_comm/pull/641, https://github.com/jsk-ros-pkg/jsk_travis/pull/110
-sudo apt-get install -y -q -qq ros-$ROS_DISTRO-roslaunch
+sudo apt-get -qq install -y ros-$ROS_DISTRO-roslaunch
 (cd /opt/ros/$ROS_DISTRO/lib/python2.7/dist-packages; wget --no-check-certificate https://patch-diff.githubusercontent.com/raw/ros/ros_comm/pull/641.diff -O /tmp/641.diff; [ "$ROS_DISTRO" == "hydro" ] && sed -i s@items@iteritems@ /tmp/641.diff ; sudo patch -p4 < /tmp/641.diff)
 
 travis_time_end  # setup_catkin


### PR DESCRIPTION
The `-q` and `-qq` switches must be appended before the apt-get command to work.
Providing `-q` and `-qq` is useless as `-qq` overrides `-q`.

man:
```
-q, --quiet
           Quiet; produces output suitable for logging, omitting progress indicators. More q's will produce more quiet up to a maximum of 2. You can also use -q=# to set the quiet
           level, overriding the configuration file. Note that quiet level 2 implies -y; you should never use -qq without a no-action modifier such as -d, --print-uris or -s as
           APT may decide to do something you did not expect. Configuration Item: quiet.
```