### PR TITLE
Fold wstool version and localname info

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -184,9 +184,13 @@ fi
 
 travis_time_end  # rosdep_install
 
+travis_time_start wstool_info
+
 $ROSWS --version
 $ROSWS info -t .
 cd ../
+
+travis_time_end  # wstool_info
 
 travis_time_start catkin_build
 


### PR DESCRIPTION
Why is this the only thing that is not folded within the travis script? Doesn't seem very important to me