### PR TITLE
enable USE_DEB

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -198,7 +198,7 @@ source /opt/ros/$ROS_DISTRO/setup.bash # re-source setup.bash for setting enviro
 # for catkin
 if [ "${TARGET_PKGS// }" == "" ]; then export TARGET_PKGS=`catkin_topological_order ${CI_SOURCE_PATH} --only-names`; fi
 if [ "${PKGS_DOWNSTREAM// }" == "" ]; then export PKGS_DOWNSTREAM=$( [ "${BUILD_PKGS// }" == "" ] && echo "$TARGET_PKGS" || echo "$BUILD_PKGS"); fi
-if [ "$BUILDER" == catkin ]; then catkin build -i -v --summarize  --no-status $BUILD_PKGS $CATKIN_PARALLEL_JOBS --make-args $ROS_PARALLEL_JOBS            ; fi
+if [ "$BUILDER" == catkin ]; then catkin build -i --summarize  --no-status $BUILD_PKGS $CATKIN_PARALLEL_JOBS --make-args $ROS_PARALLEL_JOBS            ; fi
 
 travis_time_end  # catkin_build
 
@@ -215,7 +215,7 @@ if [ "$NOT_TEST_BUILD" != "true" ]; then
 
     if [ "$BUILDER" == catkin ]; then
         source devel/setup.bash ; rospack profile # force to update ROS_PACKAGE_PATH for rostest
-        catkin run_tests -iv --no-deps --no-status $PKGS_DOWNSTREAM $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS --
+        catkin run_tests -i --no-deps --no-status $PKGS_DOWNSTREAM $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS --
         catkin_test_results build || error
     fi
 
@@ -230,7 +230,7 @@ if [ "$NOT_TEST_INSTALL" != "true" ]; then
     if [ "$BUILDER" == catkin ]; then
         catkin clean --yes
         catkin config --install
-        catkin build -i -v --summarize --no-status $BUILD_PKGS $CATKIN_PARALLEL_JOBS --make-args $ROS_PARALLEL_JOBS
+        catkin build -i --summarize --no-status $BUILD_PKGS $CATKIN_PARALLEL_JOBS --make-args $ROS_PARALLEL_JOBS
         source install/setup.bash
         rospack profile
     fi

--- a/travis.sh
+++ b/travis.sh
@@ -47,9 +47,6 @@ source ${CI_SOURCE_PATH}/$CI_PARENT_DIR/util.sh
 
 trap error ERR
 
-git branch --all
-if [ "`git diff origin/master FETCH_HEAD $CI_PARENT_DIR`" != "" ] ; then DIFF=`git diff origin/master FETCH_HEAD $CI_PARENT_DIR | grep .*Subproject | sed s'@.*Subproject commit @@' | sed 'N;s/\n/.../'`; (cd $CI_PARENT_DIR/;git log --oneline --graph --left-right --first-parent --decorate $DIFF) | tee /tmp/$$-travis-diff.log; grep -c '<' /tmp/$$-travis-diff.log && exit 1; echo "ok"; fi
-
 travis_time_start setup_ros
 
 # Define some config vars

--- a/travis.sh
+++ b/travis.sh
@@ -29,7 +29,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
-## Greatly inspired by JSK travis https://github.com/jsk-ros-pkg/jsk_travis 
+## Greatly inspired by JSK travis https://github.com/jsk-ros-pkg/jsk_travis
 ## Author: Isaac I. Y. Saito
 
 ## This is a "common" script that can be run on travis CI at a downstream github repository.
@@ -121,32 +121,43 @@ travis_time_start setup_rosws
 # Create workspace
 mkdir -p ~/ros/ws_$DOWNSTREAM_REPO_NAME/src
 cd ~/ros/ws_$DOWNSTREAM_REPO_NAME/src
-# When USE_DEB is true, the dependended packages that need to be built from source are downloaded based on .travis.rosinstall file.
-### Currently disabled
-###if [ "$USE_DEB" == false ]; then
-###    $ROSWS init .
-###    if [ -e $CI_SOURCE_PATH/.travis.rosinstall ]; then
-###        # install (maybe unreleased version) dependencies from source
-###        $ROSWS merge file://$CI_SOURCE_PATH/.travis.rosinstall
-###    fi
-###    if [ -e $CI_SOURCE_PATH/.travis.rosinstall.$ROS_DISTRO ]; then
-###        # install (maybe unreleased version) dependencies from source for specific ros version
-###        $ROSWS merge file://$CI_SOURCE_PATH/.travis.rosinstall.$ROS_DISTRO
-###    fi
-###    $ROSWS update
-###    $ROSWS set $DOWNSTREAM_REPO_NAME http://github.com/$TRAVIS_REPO_SLUG --git -y
-###fi
+case "$USE_DEB" in
+true) # When USE_DEB is true, the dependended packages that need to be built from source are downloaded based on .travis.rosinstall file.
+   $ROSWS init .
+   if [ -e $CI_SOURCE_PATH/.travis.rosinstall ]; then
+       # install (maybe unreleased version) dependencies from source
+       $ROSWS merge file://$CI_SOURCE_PATH/.travis.rosinstall
+   fi
+   if [ -e $CI_SOURCE_PATH/.travis.rosinstall.$ROS_DISTRO ]; then
+       # install (maybe unreleased version) dependencies from source for specific ros version
+       $ROSWS merge file://$CI_SOURCE_PATH/.travis.rosinstall.$ROS_DISTRO
+   fi
+   ;;
+
+source)
+   $ROSWS init .
+   $DOWNSTREAM_REPO_NAME/setup_upstream.sh -w ~/ros/ws_$DOWNSTREAM_REPO_NAME
+   $ROSWS update
+   ;;
+http://* | https://*) # When USE_DEB is an http url, use it directly
+   $ROSWS init .
+   $ROSWS merge $USE_DEB
+   ;;
+esac
+
+# download upstream packages into workspace
+if [ -e .rosinstall ]; then
+   # ensure that the downstream is not in .rosinstall
+   $ROSWS rm $DOWNSTREAM_REPO_NAME
+   $ROSWS update
+fi
 # CI_SOURCE_PATH is the path of the downstream repository that we are testing. Link it to the catkin workspace
 ln -s $CI_SOURCE_PATH .
-####if [ "$USE_DEB" == source -a -e $DOWNSTREAM_REPO_NAME/setup_upstream.sh ]; then $ROSWS init .; $DOWNSTREAM_REPO_NAME/setup_upstream.sh -w ~/ros/ws_$DOWNSTREAM_REPO_NAME ; $ROSWS update; fi
+
 # Disable metapackage
 find -L . -name package.xml -print -exec ${CI_SOURCE_PATH}/$CI_PARENT_DIR/check_metapackage.py {} \; -a -exec bash -c 'touch `dirname ${1}`/CATKIN_IGNORE' funcname {} \;
 
 source /opt/ros/$ROS_DISTRO/setup.bash # ROS_PACKAGE_PATH is important for rosdep
-# Save .rosinstall file of this tested downstream repo, only during the runtime on travis CI
-if [ ! -e .rosinstall ]; then
-    echo "- git: {local-name: $DOWNSTREAM_REPO_NAME, uri: 'http://github.com/$TRAVIS_REPO_SLUG'}" >> .rosinstall
-fi
 
 travis_time_end  # setup_rosws
 
@@ -161,7 +172,7 @@ travis_time_end  # before_script
 travis_time_start rosdep_install
 
 # Run "rosdep install" command. Avoid manifest.xml files if any.
-if [ -e ${CI_SOURCE_PATH}/$CI_PARENT_DIR/rosdep-install.sh ]; then 
+if [ -e ${CI_SOURCE_PATH}/$CI_PARENT_DIR/rosdep-install.sh ]; then
     ${CI_SOURCE_PATH}/$CI_PARENT_DIR/rosdep-install.sh
 fi
 
@@ -170,7 +181,7 @@ travis_time_end  # rosdep_install
 # Start prerelease, and once it finishs then finish this script too.
 # This block needs to be here (i.e. After rosdep is done) because catkin_test_results isn't available until up to this point.
 travis_time_start prerelease_from_travis_sh
-if [ "$PRERELEASE" == true ] && [ -e ${CI_SOURCE_PATH}/$CI_PARENT_DIR/ros_pre-release.sh ]; then 
+if [ "$PRERELEASE" == true ] && [ -e ${CI_SOURCE_PATH}/$CI_PARENT_DIR/ros_pre-release.sh ]; then
   ${CI_SOURCE_PATH}/$CI_PARENT_DIR/ros_pre-release.sh
   catkin_test_results build && (echo 'ROS Prerelease Test went successful.'; exit 0) || error
 fi
@@ -196,7 +207,7 @@ travis_time_end  # catkin_build
 
 if [ "$NOT_TEST_BUILD" != "true" ]; then
     travis_time_start catkin_run_tests
-    
+
     # Patches for rostest that are only available in newer codes.
     # Some are already available via DEBs so that patches for them are not needed, but because EOLed distros (e.g. Hydro) where those patches are not released into may be still tested, all known patches are applied here.
     if [ "$ROS_DISTRO" == "hydro" ]; then
@@ -204,13 +215,13 @@ if [ "$NOT_TEST_BUILD" != "true" ]; then
         (cd /opt/ros/$ROS_DISTRO/lib/python2.7/dist-packages; wget --no-check-certificate https://patch-diff.githubusercontent.com/raw/ros/ros/pull/82.diff -O - | sudo patch -p4)
         (cd /opt/ros/$ROS_DISTRO/share; wget --no-check-certificate https://patch-diff.githubusercontent.com/raw/ros/ros_comm/pull/611.diff -O - | sed s@.cmake.em@.cmake@ | sed 's@/${PROJECT_NAME}@@' | sed 's@ DEPENDENCIES ${_rostest_DEPENDENCIES})@)@' | sudo patch -f -p2 || echo "ok")
     fi
-    
+
     if [ "$BUILDER" == catkin ]; then
         source devel/setup.bash ; rospack profile # force to update ROS_PACKAGE_PATH for rostest
         catkin run_tests -iv --no-deps --no-status $PKGS_DOWNSTREAM $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS --
         catkin_test_results build || error
     fi
-    
+
     travis_time_end  # catkin_run_tests
 fi
 


### PR DESCRIPTION
Was there a particular reason that USE_DEB functionality was disabled?
For MoveIt, it would be very helpful to build and test a whole workspace because there are strong interdependencies between individual repositories.

The only issue I could see, was that the actual downstream should be taken from travis but not from `.rosinstall`. I managed to ensure that by removing the downstream from .rosinstall and then using the existing link-in of the actual source folder.

I also added support for an url directly specified in USE_DEB.