### PR TITLE
enable USE_DEB

### DIFF
--- a/.ci.rosinstall.jade
+++ b/.ci.rosinstall.jade
@@ -1,0 +1,4 @@
+- git:
+    uri: https://github.com/ros-industrial/industrial_core.git
+    local-name: ros-industrial/industrial_core
+    version: jade

--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -1,0 +1,6 @@
+- git:
+    uri: https://github.com/ros-industrial/industrial_core.git
+    local-name: ros-industrial/industrial_core
+- git:
+    uri: https://github.com/ros-industrial/ros_canopen.git
+    local-name: ros-industrial/ros_canopen

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,14 @@ env:
     # - env: ROS_DISTRO=indigo PRERELEASE=true  ## Comment out because this is meaningless for always failing without prerelease testable contents in industrial_ci.
     - ROS_DISTRO=indigo PRERELEASE=true PRERELEASE_REPONAME=industrial_core PRERELEASE_DOWNSTREAM_DEPTH=0
     - ROS_DISTRO=indigo APTKEY_STORE_SKS=hkp://ha.pool.sks-keyservers.vet  # Passing wrong SKS URL as a break test. Should still pass.
+    - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=debian
+    - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=file  # Using default file name for ROSINSTALL_FILENAME
+    - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=https://github.com/ros-industrial/industrial_ci/blob/master/.travis.rosinstall
+    - ROS_DISTRO=indigo USE_DEB=true  # Checking backup compatibility wity UPSTREAM_WORKSPACE
+    - ROS_DISTRO=indigo USE_DEB=false # Checking backup compatibility wity UPSTREAM_WORKSPACE
     - ROS_DISTRO=jade   APTKEY_STORE_SKS=hkp://ha.pool.sks-keyservers.vet  # Passing wrong SKS URL as a break test. Should still pass.
     - ROS_DISTRO=jade   PRERELEASE=true PRERELEASE_REPONAME=warehouse_ros PRERELEASE_DOWNSTREAM_DEPTH=1
+    - ROS_DISTRO=jade   UPSTREAM_WORKSPACE=file  ROSINSTALL_FILENAME=.ci.rosinstall  # Testing arbitrary file name, without ROS_DISTRO suffix.
     - ROS_DISTRO=kinetic
 matrix:
   allow_failures:

--- a/README.rst
+++ b/README.rst
@@ -124,9 +124,10 @@ Note that some of these currently tied only to a single option, but we still lea
 * `PKGS_DOWNSTREAM` (default: explained): Packages in downstream to be tested. By default, `TARGET_PKGS` is used if set, if not then `BUILD_PKGS` is used.
 * `ROS_PARALLEL_JOBS` (default: -j8): Maximum number of packages to be built in parallel by the underlining build tool. As of Jan 2016, this is only enabled with `catkin_tools` (with `make` as an underlining builder).
 * `ROS_PARALLEL_TEST_JOBS` (default: -j8): Maximum number of packages which could be examined in parallel during the test run by the underlining build tool. If not set it's filled by `ROS_PARALLEL_JOBS`. As of Jan 2016, this is only enabled with `catkin_tools` (with `make` as an underlining builder).
+* `ROSINSTALL_FILENAME` (default: not set): See `USE_DEB` description.
 * `ROSWS` (default: wstool): Currently only `wstool` is available.
 * `TARGET_PKGS` (default: not set): Used to fill `PKGS_DOWNSTREAM` if it is not set. If not set packages are set using the output of `catkin_topological_order` for the source space.
-* `USE_DEB`: (NOT Implemented yet) When this is true, the dependended packages that need to be built from source are downloaded based on .travis.rosinstall file.
+* `USE_DEB` (default: true): When this is set `false`, the dependended packages that need to be built from source are downloaded based on file `$ROSINSTALL_FILENAME` in your repository. See more in `this section <https://github.com/ros-industrial/industrial_ci/blob/master/README.rst#optional-build-depended-packages-from-source>`_.
 
 Note: You see some `*PKGS*` variables. These make things very flexible but in normal usecases you don't need to be bothered with them - just keep them blank.
 
@@ -233,6 +234,26 @@ The jobs that run Prerelease Test may usually take longer than the tests defined
   :
 
 Then open a pull request using this branch against the branch that the change is subject to be merged. You do not want to actually merge this branch no matter what the Travis result is. This branch is solely for Prerelease Test purpose.
+
+(Optional) Build depended packages from source
+----------------------------------------------
+
+By default the packages your package depend upon are installed via binaries. However, you may want to build them via source in some cases (e.g. binaries are not available). There is a way to do so.
+
+Use .rosinstall file to specify the depended packages source repository
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+Standard way is 1) set `USE_DEB` as `false`, 2) create a file `$ROSINSTALL_FILENAME` using `the same file format as .rosinstall <http://docs.ros.org/independent/api/rosinstall/html/rosinstall_file_format.html>`_ and place it at the top level directory of your package.
+
+Have multiple .rosinstall files per ROS-distro
+++++++++++++++++++++++++++++++++++++++++++++++
+
+By adding `.$ROS_DISTRO` suffix to your `$ROSINSTALL_FILENAME` file, you can specify which file to use per your `$ROS_DISTRO`. E.g. `$ROSINSTALL_FILENAME.$ROS_DISTRO`.
+
+Use .rosinstall from external location
+++++++++++++++++++++++++++++++++++++++++++++++
+
+You can utilize `.rosinstall` file stored anywhere as long as its location is URL specifyable. To do so, set its URL directly to `USE_DEB`.
 
 For maintainers of industrial_ci repository
 ================================================

--- a/README.rst
+++ b/README.rst
@@ -124,10 +124,11 @@ Note that some of these currently tied only to a single option, but we still lea
 * `PKGS_DOWNSTREAM` (default: explained): Packages in downstream to be tested. By default, `TARGET_PKGS` is used if set, if not then `BUILD_PKGS` is used.
 * `ROS_PARALLEL_JOBS` (default: -j8): Maximum number of packages to be built in parallel by the underlining build tool. As of Jan 2016, this is only enabled with `catkin_tools` (with `make` as an underlining builder).
 * `ROS_PARALLEL_TEST_JOBS` (default: -j8): Maximum number of packages which could be examined in parallel during the test run by the underlining build tool. If not set it's filled by `ROS_PARALLEL_JOBS`. As of Jan 2016, this is only enabled with `catkin_tools` (with `make` as an underlining builder).
-* `ROSINSTALL_FILENAME` (default: not set): See `USE_DEB` description.
+* `ROSINSTALL_FILENAME` (default: not set): See `UPSTREAM_WORKSPACE` description.
 * `ROSWS` (default: wstool): Currently only `wstool` is available.
 * `TARGET_PKGS` (default: not set): Used to fill `PKGS_DOWNSTREAM` if it is not set. If not set packages are set using the output of `catkin_topological_order` for the source space.
-* `USE_DEB` (default: true): When this is set `false`, the dependended packages that need to be built from source are downloaded based on file `$ROSINSTALL_FILENAME` in your repository. See more in `this section <https://github.com/ros-industrial/industrial_ci/blob/master/README.rst#optional-build-depended-packages-from-source>`_.
+* `UPSTREAM_WORKSPACE` (default: debian): When this is set `file`, the dependended packages that need to be built from source are downloaded based on a `.rosinstall` file in your repository. Use `$ROSINSTALL_FILENAME` to specify the file name. See more in `this section <https://github.com/ros-industrial/industrial_ci/blob/master/README.rst#optional-build-depended-packages-from-source>`_.
+* `USE_DEB` (*DEPRECATED*: use `UPSTREAM_WORKSPACE` instead. default: true): if `true`, `UPSTREAM_WORKSPACE` will be set as `debian`. if `false`, `file` will be set. See `UPSTREAM_WORKSPACE` section for more info.
 
 Note: You see some `*PKGS*` variables. These make things very flexible but in normal usecases you don't need to be bothered with them - just keep them blank.
 
@@ -238,22 +239,35 @@ Then open a pull request using this branch against the branch that the change is
 (Optional) Build depended packages from source
 ----------------------------------------------
 
-By default the packages your package depend upon are installed via binaries. However, you may want to build them via source in some cases (e.g. binaries are not available). There is a way to do so.
+By default the packages your package depend upon are installed via binaries. However, you may want to build them via source in some cases (e.g. when depended binaries are not available). There are a few ways to do so in `industrial_ci`. Examples of all are available in `.travis.yml file on this repository <https://github.com/ros-industrial/industrial_ci/blob/master/.travis.yml>`_.
 
 Use .rosinstall file to specify the depended packages source repository
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-Standard way is 1) set `USE_DEB` as `false`, 2) create a file `$ROSINSTALL_FILENAME` using `the same file format as .rosinstall <http://docs.ros.org/independent/api/rosinstall/html/rosinstall_file_format.html>`_ and place it at the top level directory of your package.
+Standard way is 1) set `UPSTREAM_WORKSPACE` as `file`, 2) create a file `$ROSINSTALL_FILENAME` using the same file format as `.rosinstall <http://docs.ros.org/independent/api/rosinstall/html/rosinstall_file_format.html>`_ and place it at the top level directory of your package.
 
 Have multiple .rosinstall files per ROS-distro
 ++++++++++++++++++++++++++++++++++++++++++++++
 
-By adding `.$ROS_DISTRO` suffix to your `$ROSINSTALL_FILENAME` file, you can specify which file to use per your `$ROS_DISTRO`. E.g. `$ROSINSTALL_FILENAME.$ROS_DISTRO`.
+By adding `.$ROS_DISTRO` suffix to your `$ROSINSTALL_FILENAME` file, you can specify which file to use per your `$ROS_DISTRO`. So the syntax of the file name for this purpose is `$ROSINSTALL_FILENAME.$ROS_DISTRO`.
+For example, let's say you want to test multiple distros (indigo, jade) and you have `.travis.rosinstall` and `.travis.rosinstall.jade` files in your repo. You can define the Travis config as:
+
+::
+
+    env:
+      matrix:
+
+        - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=file
+        - ROS_DISTRO=jade   UPSTREAM_WORKSPACE=file
+
+With this config, for indigo default file name `.travis.rosinstall` will be seached and used if found. For jade, the file that consists of the default file name plus `.jade` suffix will be prioritized.
+
+When `$ROSINSTALL_FILENAME.$ROS_DISTRO` file isn't found, `$ROSINSTALL_FILENAME` will be used for all jobs that define `UPSTREAM_WORKSPACE`.
 
 Use .rosinstall from external location
 ++++++++++++++++++++++++++++++++++++++++++++++
 
-You can utilize `.rosinstall` file stored anywhere as long as its location is URL specifyable. To do so, set its URL directly to `USE_DEB`.
+You can utilize `.rosinstall` file stored anywhere as long as its location is URL specifyable. To do so, set its complete path URL directly to `UPSTREAM_WORKSPACE`.
 
 For maintainers of industrial_ci repository
 ================================================

--- a/travis.sh
+++ b/travis.sh
@@ -311,6 +311,8 @@ fi
 travis_time_start after_script
 
 ## BEGIN: travis' after_script
+
+set +x
 PATH=/usr/local/bin:$PATH  # for installed catkin_test_results
 PYTHONPATH=/usr/local/lib/python2.7/dist-packages:$PYTHONPATH
 if [ "${ROS_LOG_DIR// }" == "" ]; then export ROS_LOG_DIR=~/.ros/test_results; fi # http://wiki.ros.org/ROS/EnvironmentVariables#ROS_LOG_DIR
@@ -320,6 +322,6 @@ if [ "$BUILDER" == catkin -a -e ~/.ros/test_results/ ]; then catkin_test_results
 
 travis_time_end  # after_script
 
+set +x
 cd $TRAVIS_BUILD_DIR  # cd back to the repository's home directory with travis
 pwd
-

--- a/travis.sh
+++ b/travis.sh
@@ -29,7 +29,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
-## Greatly inspired by JSK travis https://github.com/jsk-ros-pkg/jsk_travis 
+## Greatly inspired by JSK travis https://github.com/jsk-ros-pkg/jsk_travis
 ## Author: Isaac I. Y. Saito
 
 ## This is a "common" script that can be run on travis CI at a downstream github repository.
@@ -157,32 +157,43 @@ travis_time_start setup_rosws
 # Create workspace
 mkdir -p ~/ros/ws_$DOWNSTREAM_REPO_NAME/src
 cd ~/ros/ws_$DOWNSTREAM_REPO_NAME/src
-# When USE_DEB is true, the dependended packages that need to be built from source are downloaded based on .travis.rosinstall file.
-### Currently disabled
-###if [ "$USE_DEB" == false ]; then
-###    $ROSWS init .
-###    if [ -e $CI_SOURCE_PATH/.travis.rosinstall ]; then
-###        # install (maybe unreleased version) dependencies from source
-###        $ROSWS merge file://$CI_SOURCE_PATH/.travis.rosinstall
-###    fi
-###    if [ -e $CI_SOURCE_PATH/.travis.rosinstall.$ROS_DISTRO ]; then
-###        # install (maybe unreleased version) dependencies from source for specific ros version
-###        $ROSWS merge file://$CI_SOURCE_PATH/.travis.rosinstall.$ROS_DISTRO
-###    fi
-###    $ROSWS update
-###    $ROSWS set $DOWNSTREAM_REPO_NAME http://github.com/$TRAVIS_REPO_SLUG --git -y
-###fi
+case "$USE_DEB" in
+true) # When USE_DEB is true, the dependended packages that need to be built from source are downloaded based on .travis.rosinstall file.
+   $ROSWS init .
+   if [ -e $CI_SOURCE_PATH/.travis.rosinstall ]; then
+       # install (maybe unreleased version) dependencies from source
+       $ROSWS merge file://$CI_SOURCE_PATH/.travis.rosinstall
+   fi
+   if [ -e $CI_SOURCE_PATH/.travis.rosinstall.$ROS_DISTRO ]; then
+       # install (maybe unreleased version) dependencies from source for specific ros version
+       $ROSWS merge file://$CI_SOURCE_PATH/.travis.rosinstall.$ROS_DISTRO
+   fi
+   ;;
+
+source)
+   $ROSWS init .
+   $DOWNSTREAM_REPO_NAME/setup_upstream.sh -w ~/ros/ws_$DOWNSTREAM_REPO_NAME
+   $ROSWS update
+   ;;
+http://* | https://*) # When USE_DEB is an http url, use it directly
+   $ROSWS init .
+   $ROSWS merge $USE_DEB
+   ;;
+esac
+
+# download upstream packages into workspace
+if [ -e .rosinstall ]; then
+   # ensure that the downstream is not in .rosinstall
+   $ROSWS rm $DOWNSTREAM_REPO_NAME
+   $ROSWS update
+fi
 # CI_SOURCE_PATH is the path of the downstream repository that we are testing. Link it to the catkin workspace
 ln -s $CI_SOURCE_PATH .
-####if [ "$USE_DEB" == source -a -e $DOWNSTREAM_REPO_NAME/setup_upstream.sh ]; then $ROSWS init .; $DOWNSTREAM_REPO_NAME/setup_upstream.sh -w ~/ros/ws_$DOWNSTREAM_REPO_NAME ; $ROSWS update; fi
+
 # Disable metapackage
 find -L . -name package.xml -print -exec ${CI_SOURCE_PATH}/$CI_PARENT_DIR/check_metapackage.py {} \; -a -exec bash -c 'touch `dirname ${1}`/CATKIN_IGNORE' funcname {} \;
 
 source /opt/ros/$ROS_DISTRO/setup.bash # ROS_PACKAGE_PATH is important for rosdep
-# Save .rosinstall file of this tested downstream repo, only during the runtime on travis CI
-if [ ! -e .rosinstall ]; then
-    echo "- git: {local-name: $DOWNSTREAM_REPO_NAME, uri: 'http://github.com/$TRAVIS_REPO_SLUG'}" >> .rosinstall
-fi
 
 travis_time_end  # setup_rosws
 
@@ -197,7 +208,7 @@ travis_time_end  # before_script
 travis_time_start rosdep_install
 
 # Run "rosdep install" command. Avoid manifest.xml files if any.
-if [ -e ${CI_SOURCE_PATH}/$CI_PARENT_DIR/rosdep-install.sh ]; then 
+if [ -e ${CI_SOURCE_PATH}/$CI_PARENT_DIR/rosdep-install.sh ]; then
     ${CI_SOURCE_PATH}/$CI_PARENT_DIR/rosdep-install.sh
 fi
 
@@ -206,7 +217,7 @@ travis_time_end  # rosdep_install
 # Start prerelease, and once it finishs then finish this script too.
 # This block needs to be here (i.e. After rosdep is done) because catkin_test_results isn't available until up to this point.
 travis_time_start prerelease_from_travis_sh
-if [ "$PRERELEASE" == true ] && [ -e ${CI_SOURCE_PATH}/$CI_PARENT_DIR/ros_pre-release.sh ]; then 
+if [ "$PRERELEASE" == true ] && [ -e ${CI_SOURCE_PATH}/$CI_PARENT_DIR/ros_pre-release.sh ]; then
   ${CI_SOURCE_PATH}/$CI_PARENT_DIR/ros_pre-release.sh
   catkin_test_results build && (echo 'ROS Prerelease Test went successful.'; exit 0) || error
 fi
@@ -232,7 +243,7 @@ travis_time_end  # catkin_build
 
 if [ "$NOT_TEST_BUILD" != "true" ]; then
     travis_time_start catkin_run_tests
-    
+
     # Patches for rostest that are only available in newer codes.
     # Some are already available via DEBs so that patches for them are not needed, but because EOLed distros (e.g. Hydro) where those patches are not released into may be still tested, all known patches are applied here.
     if [ "$ROS_DISTRO" == "hydro" ]; then
@@ -240,13 +251,13 @@ if [ "$NOT_TEST_BUILD" != "true" ]; then
         (cd /opt/ros/$ROS_DISTRO/lib/python2.7/dist-packages; wget --no-check-certificate https://patch-diff.githubusercontent.com/raw/ros/ros/pull/82.diff -O - | sudo patch -p4)
         (cd /opt/ros/$ROS_DISTRO/share; wget --no-check-certificate https://patch-diff.githubusercontent.com/raw/ros/ros_comm/pull/611.diff -O - | sed s@.cmake.em@.cmake@ | sed 's@/${PROJECT_NAME}@@' | sed 's@ DEPENDENCIES ${_rostest_DEPENDENCIES})@)@' | sudo patch -f -p2 || echo "ok")
     fi
-    
+
     if [ "$BUILDER" == catkin ]; then
         source devel/setup.bash ; rospack profile # force to update ROS_PACKAGE_PATH for rostest
         catkin run_tests -iv --no-deps --no-status $PKGS_DOWNSTREAM $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS --
         catkin_test_results build || error
     fi
-    
+
     travis_time_end  # catkin_run_tests
 fi
 

--- a/travis.sh
+++ b/travis.sh
@@ -238,7 +238,7 @@ source /opt/ros/$ROS_DISTRO/setup.bash # re-source setup.bash for setting enviro
 # for catkin
 if [ "${TARGET_PKGS// }" == "" ]; then export TARGET_PKGS=`catkin_topological_order ${CI_SOURCE_PATH} --only-names`; fi
 if [ "${PKGS_DOWNSTREAM// }" == "" ]; then export PKGS_DOWNSTREAM=$( [ "${BUILD_PKGS// }" == "" ] && echo "$TARGET_PKGS" || echo "$BUILD_PKGS"); fi
-if [ "$BUILDER" == catkin ]; then catkin build -i -v --summarize  --no-status $BUILD_PKGS $CATKIN_PARALLEL_JOBS --make-args $ROS_PARALLEL_JOBS            ; fi
+if [ "$BUILDER" == catkin ]; then catkin build -i --summarize  --no-status $BUILD_PKGS $CATKIN_PARALLEL_JOBS --make-args $ROS_PARALLEL_JOBS            ; fi
 
 travis_time_end  # catkin_build
 
@@ -255,7 +255,7 @@ if [ "$NOT_TEST_BUILD" != "true" ]; then
 
     if [ "$BUILDER" == catkin ]; then
         source devel/setup.bash ; rospack profile # force to update ROS_PACKAGE_PATH for rostest
-        catkin run_tests -iv --no-deps --no-status $PKGS_DOWNSTREAM $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS --
+        catkin run_tests -i --no-deps --no-status $PKGS_DOWNSTREAM $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS --
         catkin_test_results build || error
     fi
 
@@ -270,7 +270,7 @@ if [ "$NOT_TEST_INSTALL" != "true" ]; then
     if [ "$BUILDER" == catkin ]; then
         catkin clean --yes
         catkin config --install
-        catkin build -i -v --summarize --no-status $BUILD_PKGS $CATKIN_PARALLEL_JOBS --make-args $ROS_PARALLEL_JOBS
+        catkin build -i --summarize --no-status $BUILD_PKGS $CATKIN_PARALLEL_JOBS --make-args $ROS_PARALLEL_JOBS
         source install/setup.bash
         rospack profile
     fi

--- a/travis.sh
+++ b/travis.sh
@@ -83,9 +83,6 @@ fi
 
 trap error ERR
 
-git branch --all
-if [ "`git diff origin/master FETCH_HEAD $CI_PARENT_DIR`" != "" ] ; then DIFF=`git diff origin/master FETCH_HEAD $CI_PARENT_DIR | grep .*Subproject | sed s'@.*Subproject commit @@' | sed 'N;s/\n/.../'`; (cd $CI_PARENT_DIR/;git log --oneline --graph --left-right --first-parent --decorate $DIFF) | tee /tmp/$$-travis-diff.log; grep -c '<' /tmp/$$-travis-diff.log && exit 1; echo "ok"; fi
-
 travis_time_start setup_ros
 
 # Define some config vars

--- a/travis.sh
+++ b/travis.sh
@@ -93,6 +93,8 @@ if [ ! "$ROS_PARALLEL_JOBS" ]; then export ROS_PARALLEL_JOBS="-j8"; fi
 if [ ! "$ROS_PARALLEL_TEST_JOBS" ]; then export ROS_PARALLEL_TEST_JOBS="$ROS_PARALLEL_JOBS"; fi
 # If not specified, use ROS Shadow repository http://wiki.ros.org/ShadowRepository
 if [ ! "$ROS_REPOSITORY_PATH" ]; then export ROS_REPOSITORY_PATH="http://packages.ros.org/ros-shadow-fixed/ubuntu"; fi
+# .rosintall file name 
+if [ ! "$ROSINSTALL_FILENAME" ]; then export ROSINSTALL_FILENAME=".travis.rosinstall"; fi 
 # For apt key stores
 if [ ! "$APTKEY_STORE_HTTPS" ]; then export APTKEY_STORE_HTTPS="https://raw.githubusercontent.com/ros/rosdistro/master/ros.key"; fi
 if [ ! "$APTKEY_STORE_SKS" ]; then export APTKEY_STORE_SKS="hkp://ha.pool.sks-keyservers.net"; fi  # Export a variable for SKS URL for break-testing purpose.
@@ -155,22 +157,16 @@ travis_time_start setup_rosws
 mkdir -p ~/ros/ws_$DOWNSTREAM_REPO_NAME/src
 cd ~/ros/ws_$DOWNSTREAM_REPO_NAME/src
 case "$USE_DEB" in
-true) # When USE_DEB is true, the dependended packages that need to be built from source are downloaded based on .travis.rosinstall file.
+false) # When USE_DEB is false, the dependended packages that need to be built from source are downloaded based on $ROSINSTALL_FILENAME file.
    $ROSWS init .
-   if [ -e $CI_SOURCE_PATH/.travis.rosinstall ]; then
+   if [ -e $CI_SOURCE_PATH/$ROSINSTALL_FILENAME ]; then
        # install (maybe unreleased version) dependencies from source
-       $ROSWS merge file://$CI_SOURCE_PATH/.travis.rosinstall
+       $ROSWS merge file://$CI_SOURCE_PATH/$ROSINSTALL_FILENAME
    fi
-   if [ -e $CI_SOURCE_PATH/.travis.rosinstall.$ROS_DISTRO ]; then
+   if [ -e $CI_SOURCE_PATH/$ROSINSTALL_FILENAME.$ROS_DISTRO ]; then
        # install (maybe unreleased version) dependencies from source for specific ros version
-       $ROSWS merge file://$CI_SOURCE_PATH/.travis.rosinstall.$ROS_DISTRO
+       $ROSWS merge file://$CI_SOURCE_PATH/$ROSINSTALL_FILENAME.$ROS_DISTRO
    fi
-   ;;
-
-source)
-   $ROSWS init .
-   $DOWNSTREAM_REPO_NAME/setup_upstream.sh -w ~/ros/ws_$DOWNSTREAM_REPO_NAME
-   $ROSWS update
    ;;
 http://* | https://*) # When USE_DEB is an http url, use it directly
    $ROSWS init .

--- a/travis.sh
+++ b/travis.sh
@@ -240,7 +240,7 @@ set -x
 # for catkin
 if [ "${TARGET_PKGS// }" == "" ]; then export TARGET_PKGS=`catkin_topological_order ${CI_SOURCE_PATH} --only-names`; fi
 if [ "${PKGS_DOWNSTREAM// }" == "" ]; then export PKGS_DOWNSTREAM=$( [ "${BUILD_PKGS// }" == "" ] && echo "$TARGET_PKGS" || echo "$BUILD_PKGS"); fi
-if [ "$BUILDER" == catkin ]; then catkin build -i --summarize  --no-status $BUILD_PKGS $CATKIN_PARALLEL_JOBS --make-args $ROS_PARALLEL_JOBS            ; fi
+if [ "$BUILDER" == catkin ]; then catkin build --summarize  --no-status $BUILD_PKGS $CATKIN_PARALLEL_JOBS --make-args $ROS_PARALLEL_JOBS            ; fi
 
 travis_time_end  # catkin_build
 
@@ -259,7 +259,7 @@ if [ "$NOT_TEST_BUILD" != "true" ]; then
         set +x
         source devel/setup.bash ; rospack profile # force to update ROS_PACKAGE_PATH for rostest
         set -x
-        catkin run_tests -i --no-deps --no-status $PKGS_DOWNSTREAM $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS --
+        catkin run_tests --no-deps --no-status $PKGS_DOWNSTREAM $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS --
         catkin_test_results build || error
     fi
 
@@ -274,7 +274,7 @@ if [ "$NOT_TEST_INSTALL" != "true" ]; then
     if [ "$BUILDER" == catkin ]; then
         catkin clean --yes
         catkin config --install
-        catkin build -i --summarize --no-status $BUILD_PKGS $CATKIN_PARALLEL_JOBS --make-args $ROS_PARALLEL_JOBS
+        catkin build --summarize --no-status $BUILD_PKGS $CATKIN_PARALLEL_JOBS --make-args $ROS_PARALLEL_JOBS
         set +x
         source install/setup.bash
         set -x

--- a/travis.sh
+++ b/travis.sh
@@ -138,7 +138,7 @@ sudo apt-get -qq install -y ros-$ROS_DISTRO-roslaunch
 travis_time_end  # setup_catkin
 
 travis_time_start check_version_ros
-
+set +x
 # Check ROS tool's version
 echo -e "\e[0KROS tool's version"
 source /opt/ros/$ROS_DISTRO/setup.bash
@@ -190,7 +190,6 @@ ln -s $CI_SOURCE_PATH .
 # Disable metapackage
 find -L . -name package.xml -print -exec ${CI_SOURCE_PATH}/$CI_PARENT_DIR/check_metapackage.py {} \; -a -exec bash -c 'touch `dirname ${1}`/CATKIN_IGNORE' funcname {} \;
 
-source /opt/ros/$ROS_DISTRO/setup.bash # ROS_PACKAGE_PATH is important for rosdep
 # Save .rosinstall file of this tested downstream repo, only during the runtime on travis CI
 if [ ! -e .rosinstall ]; then
     echo "- git: {local-name: $DOWNSTREAM_REPO_NAME, uri: 'http://github.com/$TRAVIS_REPO_SLUG'}" >> .rosinstall
@@ -201,6 +200,7 @@ travis_time_end  # setup_rosws
 travis_time_start before_script
 
 ## BEGIN: travis' before_script: # Use this to prepare your build for testing e.g. copy database configurations, environment variables, etc.
+set +x
 source /opt/ros/$ROS_DISTRO/setup.bash # re-source setup.bash for setting environmet vairable for package installed via rosdep
 if [ "${BEFORE_SCRIPT// }" != "" ]; then sh -c "${BEFORE_SCRIPT}"; fi
 
@@ -234,7 +234,9 @@ travis_time_end  # wstool_info
 travis_time_start catkin_build
 
 ## BEGIN: travis' script: # All commands must exit with code 0 on success. Anything else is considered failure.
+set +x
 source /opt/ros/$ROS_DISTRO/setup.bash # re-source setup.bash for setting environmet vairable for package installed via rosdep
+set -x
 # for catkin
 if [ "${TARGET_PKGS// }" == "" ]; then export TARGET_PKGS=`catkin_topological_order ${CI_SOURCE_PATH} --only-names`; fi
 if [ "${PKGS_DOWNSTREAM// }" == "" ]; then export PKGS_DOWNSTREAM=$( [ "${BUILD_PKGS// }" == "" ] && echo "$TARGET_PKGS" || echo "$BUILD_PKGS"); fi
@@ -254,7 +256,9 @@ if [ "$NOT_TEST_BUILD" != "true" ]; then
     fi
 
     if [ "$BUILDER" == catkin ]; then
+        set +x
         source devel/setup.bash ; rospack profile # force to update ROS_PACKAGE_PATH for rostest
+        set -x
         catkin run_tests -i --no-deps --no-status $PKGS_DOWNSTREAM $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS --
         catkin_test_results build || error
     fi
@@ -271,7 +275,9 @@ if [ "$NOT_TEST_INSTALL" != "true" ]; then
         catkin clean --yes
         catkin config --install
         catkin build -i --summarize --no-status $BUILD_PKGS $CATKIN_PARALLEL_JOBS --make-args $ROS_PARALLEL_JOBS
+        set +x
         source install/setup.bash
+        set -x
         rospack profile
     fi
 

--- a/travis.sh
+++ b/travis.sh
@@ -184,7 +184,7 @@ esac
 # download upstream packages into workspace
 if [ -e .rosinstall ]; then
    # ensure that the downstream is not in .rosinstall
-   $ROSWS rm $DOWNSTREAM_REPO_NAME
+   $ROSWS rm $DOWNSTREAM_REPO_NAME || true
    $ROSWS update
 fi
 # CI_SOURCE_PATH is the path of the downstream repository that we are testing. Link it to the catkin workspace

--- a/travis.sh
+++ b/travis.sh
@@ -194,6 +194,10 @@ ln -s $CI_SOURCE_PATH .
 find -L . -name package.xml -print -exec ${CI_SOURCE_PATH}/$CI_PARENT_DIR/check_metapackage.py {} \; -a -exec bash -c 'touch `dirname ${1}`/CATKIN_IGNORE' funcname {} \;
 
 source /opt/ros/$ROS_DISTRO/setup.bash # ROS_PACKAGE_PATH is important for rosdep
+# Save .rosinstall file of this tested downstream repo, only during the runtime on travis CI
+if [ ! -e .rosinstall ]; then
+    echo "- git: {local-name: $DOWNSTREAM_REPO_NAME, uri: 'http://github.com/$TRAVIS_REPO_SLUG'}" >> .rosinstall
+fi
 
 travis_time_end  # setup_rosws
 


### PR DESCRIPTION
Was there a particular reason that USE_DEB functionality was disabled?
For MoveIt, it would be very helpful to build and test a whole workspace because there are strong interdependencies between individual repositories.

The only issue I could see, was that the actual downstream should be taken from travis but not from `.rosinstall`. I managed to ensure that by removing the downstream from .rosinstall and then using the existing link-in of the actual source folder.

I also added support for an url directly specified in USE_DEB.