### PR TITLE
Run Kinetic builds from a docker container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,12 @@ env:
     - ROS_DISTRO=indigo APTKEY_STORE_SKS=hkp://ha.pool.sks-keyservers.vet  # Passing wrong SKS URL as a break test. Should still pass.
     - ROS_DISTRO=jade   APTKEY_STORE_SKS=hkp://ha.pool.sks-keyservers.vet  # Passing wrong SKS URL as a break test. Should still pass.
     - ROS_DISTRO=jade   PRERELEASE=true PRERELEASE_REPONAME=warehouse_ros PRERELEASE_DOWNSTREAM_DEPTH=1
+    - ROS_DISTRO=kinetic
 matrix:
   allow_failures:
     - env: ROS_DISTRO=indigo PRERELEASE=true PRERELEASE_REPONAME=industrial_core PRERELEASE_DOWNSTREAM_DEPTH=0
     - env: ROS_DISTRO=jade   PRERELEASE=true PRERELEASE_REPONAME=warehouse_ros PRERELEASE_DOWNSTREAM_DEPTH=1  # Intended to fail (as of Apr 2016), to test the capability of capturing Prerelease Test failure.
+    - env: ROS_DISTRO=kinetic
 before_script:
   - CI_DIR=.ci_config
   - mkdir $CI_DIR; cp * $CI_DIR  # Need to copy, since directory starting from dot is ignoreed by catkin build. Also this folder name is used for testing both this repo itself and the "client" repositories

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:16.04
+
+MAINTAINER "ROS Industrial" "https://github.com/ros-industrial"
+
+# Install packages
+RUN apt-get update -qq
+RUN apt-get -qq install -y --force-yes git sudo lsb-release python-pip wget
+RUN apt-get clean
+ENV IN_DOCKER 1
+ENV TERM xterm

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,13 @@ FROM ubuntu:16.04
 MAINTAINER "ROS Industrial" "https://github.com/ros-industrial"
 
 # Install packages
-RUN apt-get update -qq
-RUN apt-get -qq install -y --force-yes git sudo lsb-release python-pip wget
-RUN apt-get clean
+RUN apt-get update -qq \
+    && apt-get -qq install -y \
+        git \
+        sudo \
+        lsb-release \
+        python-pip \
+        wget \
+    && apt-get clean
 ENV IN_DOCKER 1
 ENV TERM xterm

--- a/travis.sh
+++ b/travis.sh
@@ -51,6 +51,8 @@ if [[ "$ROS_DISTRO" == "kinetic" ]] && ! [ "$IN_DOCKER" ]; then
   travis_time_start build_docker_image
   docker build -t industrial-ci/xenial .ci_config
   travis_time_end  # build_docker_image
+
+  travis_time_start run_travissh_docker
   docker run \
       -e ROS_REPOSITORY_PATH \
       -e ROS_DISTRO \
@@ -75,6 +77,7 @@ if [[ "$ROS_DISTRO" == "kinetic" ]] && ! [ "$IN_DOCKER" ]; then
       -e USE_DEBROS_DISTRO \
       -v $(pwd):/root/ci_src industrial-ci/xenial \
       /bin/bash -c "cd /root/ci_src; source .ci_config/travis.sh;"
+  travis_time_end  # run_travissh_docker
   exit 0
 fi
 

--- a/travis.sh
+++ b/travis.sh
@@ -45,6 +45,39 @@ ROSWS=wstool
 
 source ${CI_SOURCE_PATH}/$CI_PARENT_DIR/util.sh
 
+# Building in 16.04 requires running this script in a docker container
+# The Dockerfile in this repository defines a Ubuntu 16.04 container
+if [[ "$ROS_DISTRO" == "kinetic" ]] && ! [ "$IN_DOCKER" ]; then
+  travis_time_start build_docker_image
+  docker build -t industrial-ci/xenial .ci_config
+  travis_time_end  # build_docker_image
+  docker run \
+      -e ROS_REPOSITORY_PATH \
+      -e ROS_DISTRO \
+      -e ADDITIONAL_DEBS \
+      -e BEFORE_SCRIPT \
+      -e BUILD_PKGS \
+      -e BUILDER \
+      -e CATKIN_PARALLEL_JOBS \
+      -e CATKIN_PARALLEL_TEST_JOBS \
+      -e CI_PARENT_DIR \
+      -e NOT_TEST_BUILD \
+      -e NOT_TEST_INSTALL \
+      -e PRERELEASE \
+      -e PRERELEASE_DOWNSTREAM_DEPTH \
+      -e PRERELEASE_REPONAME \
+      -e PKGS_DOWNSTREAM \
+      -e ROS_PARALLEL_JOBS \
+      -e ROS_PARALLEL_TEST_JOBS \
+      -e ROS_PARALLEL_JOBS \
+      -e ROSWS \
+      -e TARGET_PKGS \
+      -e USE_DEBROS_DISTRO \
+      -v $(pwd):/root/ci_src industrial-ci/xenial \
+      /bin/bash -c "cd /root/ci_src; source .ci_config/travis.sh;"
+  exit 0
+fi
+
 trap error ERR
 
 git branch --all


### PR DESCRIPTION
ROS Kinetic can only be built in Ubuntu Wily and Xenial. Xenial isn't
supported by Travis, so instead we use a Xenial docker container and
do the build in there.

The travis.sh script automatically detects whether to use docker
based on the value of ROS_DISTRO. The only change that downstream
repositories will need to make to enable ROS kinetic builds in Xenial
is add docker to their travis .travis.yml file.