### PR TITLE
[Urgent] Fix wrong github raw content URL.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
     - ROS_DISTRO=indigo APTKEY_STORE_SKS=hkp://ha.pool.sks-keyservers.vet  # Passing wrong SKS URL as a break test. Should still pass.
     - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=debian
     - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=file  # Using default file name for ROSINSTALL_FILENAME
-    - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=https://raw.githubusercontent.com//ros-industrial/industrial_ci/blob/master/.travis.rosinstall
+    - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-industrial/industrial_ci/master/.travis.rosinstall
     - ROS_DISTRO=indigo USE_DEB=true  # Checking backup compatibility with UPSTREAM_WORKSPACE
     - ROS_DISTRO=indigo USE_DEB=false # Checking backup compatibility with UPSTREAM_WORKSPACE
     - ROS_DISTRO=jade   APTKEY_STORE_SKS=hkp://ha.pool.sks-keyservers.vet  # Passing wrong SKS URL as a break test. Should still pass.


### PR DESCRIPTION
tl;dr URL for a .rosintall file is wrong so that the Travis always fail for now. This PR should fix it.

@gavanderhoorn could you review and merge if this LGT you? I have to go to bed :/

Detailed storyline (*warning*: boring):
- In https://github.com/ros-industrial/industrial_ci/pull/59 I added .rosintall files along with the logic that utilize them, and also wanted to check if the logic worked in the same PR.
- Initially I used the URL of .rosintall files on my forked repo so that Travis could find them.
- Once Travis passed, I swapped URL with [the one in `ros-industrial` organization](https://github.com/ros-industrial/industrial_ci/pull/59/commits/a68ddaba00a57eeaa020a68defc1c3373ef10faf#diff-354f30a63fb0907d4ad57269548329e3R27 ). And merge the PR without making sure the Travis passes (it shouldn't pass because the files never existed unless PR was merged). Turned out I used a wrong URL.
