### PR TITLE
Fix rosinstall include bug for Docker/Kinetic

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -161,10 +161,10 @@ Note that some of these currently tied only to a single option, but we still lea
 * `PKGS_DOWNSTREAM` (default: explained): Packages in downstream to be tested. By default, `TARGET_PKGS` is used if set, if not then `BUILD_PKGS` is used.
 * `ROS_PARALLEL_JOBS` (default: -j8): Maximum number of packages to be built in parallel by the underlining build tool. As of Jan 2016, this is only enabled with `catkin_tools` (with `make` as an underlining builder).
 * `ROS_PARALLEL_TEST_JOBS` (default: -j8): Maximum number of packages which could be examined in parallel during the test run by the underlining build tool. If not set it's filled by `ROS_PARALLEL_JOBS`. As of Jan 2016, this is only enabled with `catkin_tools` (with `make` as an underlining builder).
-* `ROSINSTALL_FILENAME` (default: not set): See `UPSTREAM_WORKSPACE` description.
 * `ROSWS` (default: wstool): Currently only `wstool` is available.
 * `TARGET_PKGS` (default: not set): Used to fill `PKGS_DOWNSTREAM` if it is not set. If not set packages are set using the output of `catkin_topological_order` for the source space.
-* `UPSTREAM_WORKSPACE` (default: debian): When this is set `file`, the dependended packages that need to be built from source are downloaded based on a `.rosinstall` file in your repository. Use `$ROSINSTALL_FILENAME` to specify the file name. See more in `this section <https://github.com/ros-industrial/industrial_ci/blob/master/README.rst#optional-build-depended-packages-from-source>`_.
+* `UPSTREAM_WORKSPACE` (default: debian): When set as `file`, the dependended packages that need to be built from source are downloaded based on a `.rosinstall` file in your repository. Use `$ROSINSTALL_FILENAME` to specify the file name. When set to a URL, downloads the rosinstall configuration from an ``http`` location. See more in `this section <https://github.com/ros-industrial/industrial_ci/blob/master/README.rst#optional-build-depended-packages-from-source>`_.
+* `ROSINSTALL_FILENAME` (default: not set): Only used when `UPSTREAM_WORKSPACE` is set to `file`. See `UPSTREAM_WORKSPACE` description.
 * `USE_DEB` (*DEPRECATED*: use `UPSTREAM_WORKSPACE` instead. default: true): if `true`, `UPSTREAM_WORKSPACE` will be set as `debian`. if `false`, `file` will be set. See `UPSTREAM_WORKSPACE` section for more info.
 
 Note: You see some `*PKGS*` variables. These make things very flexible but in normal usecases you don't need to be bothered with them - just keep them blank.
@@ -183,7 +183,7 @@ Sometimes CI config stored in `industrial_ci` repo may not be sufficient for you
 
 ::
 
-  script: 
+  script:
     - source .ci_config/travis.sh
     - source ./travis.sh
 
@@ -216,7 +216,7 @@ This standard `git submodule` command:
 
 ::
 
-  script: 
+  script:
     - source .ci_config/travis.sh
     #- source ./travis.sh  # Optional. Explained later
 
@@ -282,16 +282,16 @@ You may want to add custom steps prior to the setup defined in `./travis.sh <./t
 
 * A device driver package X in your repository or in your repository's dependency requires a prorietary library installed. This library is publicly available, but not via apt or any package management system and thus the only way you can install it is in a classic way (unzip, run installer etc.) (`More discussion <https://github.com/ros-industrial/industrial_ci/issues/14>`_).
 
-In this case, add `source`d scripts before `travis.sh` gets called (see below for an example). 
+In this case, add `source`d scripts before `travis.sh` gets called (see below for an example).
 
 ::
 
-  script: 
+  script:
     - source ./your_custom_PREprocess.sh
     - source .ci_config/travis.sh
     - source ./your_custom_POSTprocess.sh
 
-In the above case, in both `.ci_config/travis.sh` and `your_custom_POSTprocess.sh` the environment is kept from previous script(s), so whatever is done in previous scripts remains. 
+In the above case, in both `.ci_config/travis.sh` and `your_custom_POSTprocess.sh` the environment is kept from previous script(s), so whatever is done in previous scripts remains.
 
 (Optional) Build depended packages from source
 ----------------------------------------------
@@ -301,7 +301,15 @@ By default the packages your package depend upon are installed via binaries. How
 Use .rosinstall file to specify the depended packages source repository
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-Standard way is 1) set `UPSTREAM_WORKSPACE` as `file`, 2) create a file `$ROSINSTALL_FILENAME` using the same file format as `.rosinstall <http://docs.ros.org/independent/api/rosinstall/html/rosinstall_file_format.html>`_ and place it at the top level directory of your package.
+For using a rosinstall file located locally within the repository:
+
+1) set `UPSTREAM_WORKSPACE` as `file`
+2) create a file `$ROSINSTALL_FILENAME` using the same file format as `.rosinstall <http://docs.ros.org/independent/api/rosinstall/html/rosinstall_file_format.html>`_ and place it at the top level directory of your package.
+
+For using a rosinstall file located externally from the repository:
+
+1) set `UPSTREAM_WORKSPACE` to some URL, for example: `https://github.com/ros-planning/moveit_docs/blob/jade-devel/moveit.rosinstall`
+2) do not specify `$ROSINSTALL_FILENAME`
 
 Have multiple .rosinstall files per ROS-distro
 ++++++++++++++++++++++++++++++++++++++++++++++

--- a/README.rst
+++ b/README.rst
@@ -161,10 +161,10 @@ Note that some of these currently tied only to a single option, but we still lea
 * `PKGS_DOWNSTREAM` (default: explained): Packages in downstream to be tested. By default, `TARGET_PKGS` is used if set, if not then `BUILD_PKGS` is used.
 * `ROS_PARALLEL_JOBS` (default: -j8): Maximum number of packages to be built in parallel by the underlining build tool. As of Jan 2016, this is only enabled with `catkin_tools` (with `make` as an underlining builder).
 * `ROS_PARALLEL_TEST_JOBS` (default: -j8): Maximum number of packages which could be examined in parallel during the test run by the underlining build tool. If not set it's filled by `ROS_PARALLEL_JOBS`. As of Jan 2016, this is only enabled with `catkin_tools` (with `make` as an underlining builder).
+* `ROSINSTALL_FILENAME` (default: not set): Only used when `UPSTREAM_WORKSPACE` is set to `file`. See `UPSTREAM_WORKSPACE` description.
 * `ROSWS` (default: wstool): Currently only `wstool` is available.
 * `TARGET_PKGS` (default: not set): Used to fill `PKGS_DOWNSTREAM` if it is not set. If not set packages are set using the output of `catkin_topological_order` for the source space.
 * `UPSTREAM_WORKSPACE` (default: debian): When set as `file`, the dependended packages that need to be built from source are downloaded based on a `.rosinstall` file in your repository. Use `$ROSINSTALL_FILENAME` to specify the file name. When set to a URL, downloads the rosinstall configuration from an ``http`` location. See more in `this section <https://github.com/ros-industrial/industrial_ci/blob/master/README.rst#optional-build-depended-packages-from-source>`_.
-* `ROSINSTALL_FILENAME` (default: not set): Only used when `UPSTREAM_WORKSPACE` is set to `file`. See `UPSTREAM_WORKSPACE` description.
 * `USE_DEB` (*DEPRECATED*: use `UPSTREAM_WORKSPACE` instead. default: true): if `true`, `UPSTREAM_WORKSPACE` will be set as `debian`. if `false`, `file` will be set. See `UPSTREAM_WORKSPACE` section for more info.
 
 Note: You see some `*PKGS*` variables. These make things very flexible but in normal usecases you don't need to be bothered with them - just keep them blank.

--- a/travis.sh
+++ b/travis.sh
@@ -80,6 +80,8 @@ if [[ "$ROS_DISTRO" == "kinetic" ]] && ! [ "$IN_DOCKER" ]; then
       -e ROSWS \
       -e TARGET_PKGS \
       -e USE_DEBROS_DISTRO \
+      -e UPSTREAM_WORKSPACE \
+      -e ROSINSTALL_FILENAME \
       -v $(pwd):/root/ci_src industrial-ci/xenial \
       /bin/bash -c "cd /root/ci_src; source .ci_config/travis.sh;"
   retval=$?
@@ -97,8 +99,8 @@ if [ ! "$ROS_PARALLEL_JOBS" ]; then export ROS_PARALLEL_JOBS="-j8"; fi
 if [ ! "$ROS_PARALLEL_TEST_JOBS" ]; then export ROS_PARALLEL_TEST_JOBS="$ROS_PARALLEL_JOBS"; fi
 # If not specified, use ROS Shadow repository http://wiki.ros.org/ShadowRepository
 if [ ! "$ROS_REPOSITORY_PATH" ]; then export ROS_REPOSITORY_PATH="http://packages.ros.org/ros-shadow-fixed/ubuntu"; fi
-# .rosintall file name 
-if [ ! "$ROSINSTALL_FILENAME" ]; then export ROSINSTALL_FILENAME=".travis.rosinstall"; fi 
+# .rosintall file name
+if [ ! "$ROSINSTALL_FILENAME" ]; then export ROSINSTALL_FILENAME=".travis.rosinstall"; fi
 # For apt key stores
 if [ ! "$APTKEY_STORE_HTTPS" ]; then export APTKEY_STORE_HTTPS="https://raw.githubusercontent.com/ros/rosdistro/master/ros.key"; fi
 if [ ! "$APTKEY_STORE_SKS" ]; then export APTKEY_STORE_SKS="hkp://ha.pool.sks-keyservers.net"; fi  # Export a variable for SKS URL for break-testing purpose.
@@ -253,7 +255,7 @@ travis_time_start catkin_build
 ## BEGIN: travis' script: # All commands must exit with code 0 on success. Anything else is considered failure.
 source /opt/ros/$ROS_DISTRO/setup.bash # re-source setup.bash for setting environmet vairable for package installed via rosdep
 # for catkin
-if [ "${_TARGET_PKGS// }" == "" ]; then export _TARGET_PKGS=`catkin_topological_order ${CI_SOURCE_PATH} --only-names`; fi  # `_TARGET_PKGS` (default: not set): If not set, the packages in the output of `catkin_topological_order` from the source space of your repo are to be set. This is also used to fill `PKGS_DOWNSTREAM` if it is not set. 
+if [ "${_TARGET_PKGS// }" == "" ]; then export _TARGET_PKGS=`catkin_topological_order ${CI_SOURCE_PATH} --only-names`; fi  # `_TARGET_PKGS` (default: not set): If not set, the packages in the output of `catkin_topological_order` from the source space of your repo are to be set. This is also used to fill `PKGS_DOWNSTREAM` if it is not set.
 if [ "${_PKGS_DOWNSTREAM// }" == "" ]; then export _PKGS_DOWNSTREAM=$( [ "${BUILD_PKGS_WHITELIST// }" == "" ] && echo "$_TARGET_PKGS" || echo "$BUILD_PKGS_WHITELIST"); fi
 if [ "$BUILDER" == catkin ]; then catkin build -i -v --summarize  --no-status $BUILD_PKGS_WHITELIST $CATKIN_PARALLEL_JOBS --make-args $ROS_PARALLEL_JOBS            ; fi
 

--- a/travis.sh
+++ b/travis.sh
@@ -58,6 +58,7 @@ if [[ "$ROS_DISTRO" == "kinetic" ]] && ! [ "$IN_DOCKER" ]; then
   travis_time_end  # build_docker_image
 
   travis_time_start run_travissh_docker
+  export DOWNSTREAM_REPO_NAME=${PWD##*/}
   docker run \
       -e ROS_REPOSITORY_PATH \
       -e ROS_DISTRO \
@@ -82,8 +83,8 @@ if [[ "$ROS_DISTRO" == "kinetic" ]] && ! [ "$IN_DOCKER" ]; then
       -e USE_DEBROS_DISTRO \
       -e UPSTREAM_WORKSPACE \
       -e ROSINSTALL_FILENAME \
-      -v $(pwd):/root/ci_src industrial-ci/xenial \
-      /bin/bash -c "cd /root/ci_src; source .ci_config/travis.sh;"
+      -v $(pwd):/root/$DOWNSTREAM_REPO_NAME industrial-ci/xenial \
+      /bin/bash -c "cd /root/$DOWNSTREAM_REPO_NAME; source .ci_config/travis.sh;"
   retval=$?
   if [ $retval -eq 0 ]; then HIT_ENDOFSCRIPT=true; success 0; else exit; fi  # Call  travis_time_end  run_travissh_docker
 fi


### PR DESCRIPTION
Was missing from Docker command:

```
      -e UPSTREAM_WORKSPACE \
      -e ROSINSTALL_FILENAME \
```
Which was causing this Travis failure: https://travis-ci.org/ros-planning/moveit_core/jobs/142616513

Also:

- Was not specifying DOWNSTREAM_REPO_NAME within Docker, so multiple instances of the same target repo was being downloaded
- Better document how to use an external rosinstall file (located outside target repo)
- My editor autoremoved whitespace