### PR TITLE
Better handling a cornercase where USE_DEB=true and UPSTREAM_WORKSPACE=file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
     - ROS_DISTRO=indigo APTKEY_STORE_SKS=hkp://ha.pool.sks-keyservers.vet  # Passing wrong SKS URL as a break test. Should still pass.
     - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=debian
     - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=file  # Using default file name for ROSINSTALL_FILENAME
+    - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=file USE_DEB=true  # Expected to fail. See https://github.com/ros-industrial/industrial_ci/pull/74
     - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-industrial/industrial_ci/master/.travis.rosinstall
     - ROS_DISTRO=indigo USE_DEB=true  # Checking backup compatibility with UPSTREAM_WORKSPACE
     - ROS_DISTRO=indigo USE_DEB=false # Checking backup compatibility with UPSTREAM_WORKSPACE
@@ -35,6 +36,7 @@ matrix:
   allow_failures:
     - env: ROS_DISTRO=indigo PRERELEASE=true PRERELEASE_REPONAME=industrial_core PRERELEASE_DOWNSTREAM_DEPTH=0
     - env: ROS_DISTRO=indigo PRERELEASE=true PRERELEASE_REPONAME=ros_canopen
+    - env: ROS_DISTRO=indigo UPSTREAM_WORKSPACE=file USE_DEB=true  # Expected to fail. See https://github.com/ros-industrial/industrial_ci/pull/74
     - env: ROS_DISTRO=jade   PRERELEASE=true PRERELEASE_REPONAME=warehouse_ros PRERELEASE_DOWNSTREAM_DEPTH=1  # Intended to fail (as of Apr 2016), to test the capability of capturing Prerelease Test failure.
     - env: ROS_DISTRO=kinetic
 before_script:

--- a/README.rst
+++ b/README.rst
@@ -296,10 +296,16 @@ In the above case, in both `.ci_config/travis.sh` and `your_custom_POSTprocess.s
 (Optional) Build depended packages from source
 ----------------------------------------------
 
-By default the packages your package depend upon are installed via binaries. However, you may want to build them via source in some cases (e.g. when depended binaries are not available). There are a few ways to do so in `industrial_ci`. Examples of all are available in `.travis.yml file on this repository <https://github.com/ros-industrial/industrial_ci/blob/master/.travis.yml>`_.
+By default the packages your package depend upon are installed via binaries. However, you may want to build them via source in some cases (e.g. when depended binaries are not available). There are a few ways to do so in `industrial_ci`; By utilizing `rosinstall <http://docs.ros.org/independent/api/rosinstall/html/>`_, you can specify the packages that you want to be built from source.
+
+Note that while building the designated packages from source, other packages are resolved still from binary automatically by `rosdep <http://wiki.ros.org/rosdep>`_.
+
+Examples of how to enable all of the following cases are available in `.travis.yml file on this repository <https://github.com/ros-industrial/industrial_ci/blob/master/.travis.yml>`_.
 
 Use .rosinstall file to specify the depended packages source repository
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+WARNING: In all cases where you want to utilize `.rosinstall` (or similar name) files, be sure to set `USE_DEB` as `false`, or simply not define it.
 
 For using a rosinstall file located locally within the repository:
 

--- a/travis.sh
+++ b/travis.sh
@@ -108,6 +108,7 @@ if [ ! "$APTKEY_STORE_SKS" ]; then export APTKEY_STORE_SKS="hkp://ha.pool.sks-ke
 if [ ! "$HASHKEY_SKS" ]; then export HASHKEY_SKS="0xB01FA116"; fi
 if [ "$USE_DEB" ]; then  # USE_DEB is deprecated. See https://github.com/ros-industrial/industrial_ci/pull/47#discussion_r64882878 for the discussion.
     if [ "$USE_DEB" != "true" ]; then export UPSTREAM_WORKSPACE="file";
+    elif [ "$USE_DEB" == true ] && [ "$UPSTREAM_WORKSPACE" == "file" ]; then echo "You have USE_DEB == true AND UPSTREAM_WORKSPACE == file, which is contradictory. Please review https://github.com/ros-industrial/industrial_ci/blob/master/README.rst#optional-build-depended-packages-from-source for setup. Exiting script."; error;
     else export UPSTREAM_WORKSPACE="debian";
     fi
 fi


### PR DESCRIPTION
Found that the current document might be confusing for users (at https://github.com/ros-industrial/staubli_experimental/pull/12).

`USE_DEB` variable was already there since when this package was initially introduced but recently it's gone deprecated https://github.com/ros-industrial/industrial_ci/pull/59, and having it unchanged while adding .rosinstall would collide.

@gavanderhoorn Would you find this change clear enough?  