### PR TITLE
Only use catkin_test_results --verbose if it exists

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -342,6 +342,18 @@ Use .rosinstall from external location
 
 You can utilize `.rosinstall` file stored anywhere as long as its location is URL specifyable. To do so, set its complete path URL directly to `UPSTREAM_WORKSPACE`.
 
+(Optional) Checking older ROS distros with industrial_ci
+--------------------------------------------------------
+
+For the older ROS distributions than `those that are supported <https://github.com/ros-industrial/industrial_ci#supported-ros-distributions>`_, you may still be able to use `industrial_ci`. Here's how to do so taking ROS `Hydro` as an example.
+
+For `Travis CI`, you need at least the following changes in `.travis.yml`:
+
+* Use `dist: precise` (instead of e.g. "`dist: trusty`").
+* Define `ROS_DISTRO` with  `hydro` (so have `ROS_DISTRO="hydro"`).
+
+A successful example from `swri-robotics/mapviz <https://github.com/swri-robotics/mapviz/blob/49b0c5748950a956804e1976cfd7a224fa3f3f7d/.travis.yml>`_.
+
 For maintainers of industrial_ci repository
 ================================================
 

--- a/industrial_ci/ci_main.sh
+++ b/industrial_ci/ci_main.sh
@@ -87,6 +87,10 @@ travis_time_start init_travis_environment
 # Define more env vars
 BUILDER=catkin
 ROSWS=wstool
+# For compatibilility with hydro catkin, which has no --verbose flag
+CATKIN_TEST_RESULTS_CMD="catkin_test_results"
+if [ catkin_test_results --verbose 1>/dev/null 2>/dev/null; then CATKIN_TEST_RESULTS_CMD="catkin_test_results --verbose"; fi
+
 if [ ! "$CATKIN_PARALLEL_JOBS" ]; then export CATKIN_PARALLEL_JOBS="-p4"; fi
 if [ ! "$CATKIN_PARALLEL_TEST_JOBS" ]; then export CATKIN_PARALLEL_TEST_JOBS="$CATKIN_PARALLEL_JOBS"; fi
 if [ ! "$ROS_PARALLEL_JOBS" ]; then export ROS_PARALLEL_JOBS="-j8"; fi
@@ -321,9 +325,6 @@ travis_time_start after_script
 ## BEGIN: travis' after_script
 PATH=/usr/local/bin:$PATH  # for installed catkin_test_results
 PYTHONPATH=/usr/local/lib/python2.7/dist-packages:$PYTHONPATH
-# For compatibilility with hydro catkin, which has no --verbose flag
-CATKIN_TEST_RESULTS_CMD="catkin_test_results"
-if [ catkin_test_results --verbose 1>/dev/null 2>/dev/null; then CATKIN_TEST_RESULTS_CMD="catkin_test_results --verbose"; fi
 
 if [ "${ROS_LOG_DIR// }" == "" ]; then export ROS_LOG_DIR=~/.ros/test_results; fi # http://wiki.ros.org/ROS/EnvironmentVariables#ROS_LOG_DIR
 if [ "$BUILDER" == catkin -a -e $ROS_LOG_DIR ]; then $CATKIN_TEST_RESULTS_CMD --all $ROS_LOG_DIR || error; fi

--- a/industrial_ci/ci_main.sh
+++ b/industrial_ci/ci_main.sh
@@ -321,10 +321,14 @@ travis_time_start after_script
 ## BEGIN: travis' after_script
 PATH=/usr/local/bin:$PATH  # for installed catkin_test_results
 PYTHONPATH=/usr/local/lib/python2.7/dist-packages:$PYTHONPATH
+# For compatibilility with hydro catkin, which has no --verbose flag
+CATKIN_TEST_RESULTS_CMD="catkin_test_results"
+if [ catkin_test_results --verbose 1>/dev/null 2>/dev/null; then CATKIN_TEST_RESULTS_CMD="catkin_test_results --verbose"; fi
+
 if [ "${ROS_LOG_DIR// }" == "" ]; then export ROS_LOG_DIR=~/.ros/test_results; fi # http://wiki.ros.org/ROS/EnvironmentVariables#ROS_LOG_DIR
-if [ "$BUILDER" == catkin -a -e $ROS_LOG_DIR ]; then catkin_test_results --verbose --all $ROS_LOG_DIR || error; fi
-if [ "$BUILDER" == catkin -a -e ~/ros/ws_$TARGET_REPO_NAME/build/ ]; then catkin_test_results --verbose --all ~/ros/ws_$TARGET_REPO_NAME/build/ || error; fi
-if [ "$BUILDER" == catkin -a -e ~/.ros/test_results/ ]; then catkin_test_results --verbose --all ~/.ros/test_results/ || error; fi
+if [ "$BUILDER" == catkin -a -e $ROS_LOG_DIR ]; then $CATKIN_TEST_RESULTS_CMD --all $ROS_LOG_DIR || error; fi
+if [ "$BUILDER" == catkin -a -e ~/ros/ws_$TARGET_REPO_NAME/build/ ]; then $CATKIN_TEST_RESULTS_CMD --all ~/ros/ws_$TARGET_REPO_NAME/build/ || error; fi
+if [ "$BUILDER" == catkin -a -e ~/.ros/test_results/ ]; then $CATKIN_TEST_RESULTS_CMD --all ~/.ros/test_results/ || error; fi
 
 travis_time_end  # after_script
 


### PR DESCRIPTION
Although industrial_ci isn't targeted at ROS hydro, I still maintain a hydro branch of some repositories to support legacy projects. The hydro version of catkin_test_results has no --verbose option, which causes the test to fail when used on hydro.

This PR checks to see if the --verbose flag exists before using it.

This was tested on a hydro branch of swri_robotics/mapviz: [before (failing)](https://travis-ci.org/swri-robotics/mapviz/builds/156967693) and [after (passing)](https://travis-ci.org/swri-robotics/mapviz/builds/157317100).