### PR TITLE
Fix usermod error on docker-based ROS Prerelease

### DIFF
--- a/industrial_ci/ros_pre-release.sh
+++ b/industrial_ci/ros_pre-release.sh
@@ -52,7 +52,7 @@ function install_ros() {
 }
 
 function setup_docker() {
-    sudo usermod -aG docker ubuntu
+    sudo usermod -aG docker $(whoami)
     # ROS Buildfarm for prerelease http://wiki.ros.org/regression_tests#How_do_I_setup_my_system_to_run_a_prerelease.3F
     sudo -E sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
     sudo -E apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv-key 0xB01FA116


### PR DESCRIPTION
Without knowing, [`docker` install instruction](https://docs.docker.com/engine/installation/linux/ubuntulinux/) might have been updated to NOT use the user `ubuntu`. They [surely updated URL of the page](http://wiki.ros.org/action/info/regression_tests?action=diff&rev2=58&rev1=57).

This fixes issues like https://github.com/ros-industrial/ros_canopen/pull/193#issuecomment-254575036 (confirmed on my fork that with this change Travis passed https://github.com/130s/ros_canopen/pull/3).