### PR TITLE
fix kinetic prelease test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
     - ROS_DISTRO=indigo CATKIN_PARALLEL_JOBS='-p1' ROS_PARALLEL_JOBS='-j1'  # Intend build on low-power platform
     # - env: ROS_DISTRO=indigo PRERELEASE=true  ## Comment out because this is meaningless for always failing without prerelease testable contents in industrial_ci.
     - ROS_DISTRO=indigo PRERELEASE=true PRERELEASE_REPONAME=industrial_core PRERELEASE_DOWNSTREAM_DEPTH=0
-    - ROS_DISTRO=indigo PRERELEASE=true PRERELEASE_REPONAME=ros_canopen
+    - ROS_DISTRO=kinetic PRERELEASE=true PRERELEASE_REPONAME=ros_canopen
     - ROS_DISTRO=indigo APTKEY_STORE_SKS=hkp://ha.pool.sks-keyservers.vet  # Passing wrong SKS URL as a break test. Should still pass.
     - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=debian
     - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=file  # Using default file name for ROSINSTALL_FILENAME
@@ -42,7 +42,6 @@ env:
 matrix:
   allow_failures:
     - env: ROS_DISTRO=indigo PRERELEASE=true PRERELEASE_REPONAME=industrial_core PRERELEASE_DOWNSTREAM_DEPTH=0
-    - env: ROS_DISTRO=indigo PRERELEASE=true PRERELEASE_REPONAME=ros_canopen
     - env: ROS_DISTRO=indigo UPSTREAM_WORKSPACE=file USE_DEB=true  # Expected to fail. See https://github.com/ros-industrial/industrial_ci/pull/74
     - env: ROS_DISTRO=indigo ADDITIONAL_DEBS="ros-hydro-opencv3"  # This should fail (trying from a wrong distro).
     - env: ROS_DISTRO=jade   PRERELEASE=true PRERELEASE_REPONAME=warehouse_ros PRERELEASE_DOWNSTREAM_DEPTH=1  # Intended to fail (as of Apr 2016), to test the capability of capturing Prerelease Test failure.

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
     - ROS_DISTRO=indigo CATKIN_PARALLEL_JOBS='-p1' ROS_PARALLEL_JOBS='-j1'  # Intend build on low-power platform
     # - env: ROS_DISTRO=indigo PRERELEASE=true  ## Comment out because this is meaningless for always failing without prerelease testable contents in industrial_ci.
     - ROS_DISTRO=indigo PRERELEASE=true PRERELEASE_REPONAME=industrial_core PRERELEASE_DOWNSTREAM_DEPTH=0
-    - ROS_DISTRO=kinetic PRERELEASE=true PRERELEASE_REPONAME=ros_canopen
+    - ROS_DISTRO=kinetic PRERELEASE=true PRERELEASE_REPONAME=std_msgs
     - ROS_DISTRO=indigo APTKEY_STORE_SKS=hkp://ha.pool.sks-keyservers.vet  # Passing wrong SKS URL as a break test. Should still pass.
     - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=debian
     - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=file  # Using default file name for ROSINSTALL_FILENAME

--- a/industrial_ci/ros_pre-release.sh
+++ b/industrial_ci/ros_pre-release.sh
@@ -40,9 +40,12 @@ if [ ! "$PRERELEASE_DOWNSTREAM_DEPTH" ]; then export PRERELEASE_DOWNSTREAM_DEPTH
 if [ ! "$PRERELEASE_REPONAME" ]; then PRERELEASE_REPONAME=$(echo $TRAVIS_REPO_SLUG | cut -d'/' -f 2); fi
 #echo "PRERELEASE_REPONAME = ${PRERELEASE_REPONAME}"  # This shouldn't be echoed since this would become a return value of this entire script.
 
+CATKIN_DISTRO=$ROS_DISTRO
+
 case "$ROS_DISTRO" in
 "kinetic")
     os_code_name="xenial"
+    CATKIN_DISTRO="jade"
     ;;
 *)
     os_code_name=$(lsb_release -sc)
@@ -53,12 +56,12 @@ if [ ! "$PRERELEASE_OS_CODENAME" ]; then PRERELEASE_OS_CODENAME=$os_code_name; f
 # File-global vars and 
 RESULT_PRERELEASE=-1
 
-function install_ros() {
+function install_catkin() {
     # Set apt repo
     sudo -E sh -c 'echo "deb $ROS_REPOSITORY_PATH `lsb_release -cs` main" > /etc/apt/sources.list.d/ros-latest.list'
     # Common ROS install preparation
     wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
-    sudo apt-get -qq install -y ros-$ROS_DISTRO-catkin && source /opt/ros/$ROS_DISTRO/setup.bash || (echo 'ros-latest.list content: \n'; cat /etc/apt/sources.list.d/ros-latest.list; error;)
+    sudo apt-get -qq update && sudo apt-get -qq install -y ros-$CATKIN_DISTRO-catkin && source /opt/ros/$CATKIN_DISTRO/setup.bash || (echo 'ros-latest.list content: \n'; cat /etc/apt/sources.list.d/ros-latest.list; error;)
 }
 
 function setup_docker() {
@@ -73,7 +76,7 @@ function setup_docker() {
 
 function run_ros_prerelease() {
     travis_time_start install_for_display_testresult
-    install_ros
+    install_catkin
     travis_time_end  # install_for_display_testresult
 
     travis_time_start setup_docker

--- a/industrial_ci/ros_pre-release.sh
+++ b/industrial_ci/ros_pre-release.sh
@@ -40,6 +40,16 @@ if [ ! "$PRERELEASE_DOWNSTREAM_DEPTH" ]; then export PRERELEASE_DOWNSTREAM_DEPTH
 if [ ! "$PRERELEASE_REPONAME" ]; then PRERELEASE_REPONAME=$(echo $TRAVIS_REPO_SLUG | cut -d'/' -f 2); fi
 #echo "PRERELEASE_REPONAME = ${PRERELEASE_REPONAME}"  # This shouldn't be echoed since this would become a return value of this entire script.
 
+case "$ROS_DISTRO" in
+"kinetic")
+    os_code_name="xenial"
+    ;;
+*)
+    os_code_name=$(lsb_release -sc)
+    ;;
+esac
+if [ ! "$PRERELEASE_OS_CODENAME" ]; then PRERELEASE_OS_CODENAME=$os_code_name; fi
+
 # File-global vars and 
 RESULT_PRERELEASE=-1
 
@@ -71,7 +81,7 @@ function run_ros_prerelease() {
     travis_time_end  # setup_docker
 
     travis_time_start setup_prerelease_scripts
-    mkdir -p /tmp/prerelease_job; cd /tmp/prerelease_job; generate_prerelease_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml $ROS_DISTRO default ubuntu trusty amd64 ${PRERELEASE_REPONAME} --level $PRERELEASE_DOWNSTREAM_DEPTH --output-dir ./
+    mkdir -p /tmp/prerelease_job; cd /tmp/prerelease_job; generate_prerelease_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml $ROS_DISTRO default ubuntu ${PRERELEASE_OS_CODENAME} amd64 ${PRERELEASE_REPONAME} --level $PRERELEASE_DOWNSTREAM_DEPTH --output-dir ./
     travis_time_end  # setup_prerelease_scripts
 
     travis_time_start run_prerelease

--- a/industrial_ci/ros_pre-release.sh
+++ b/industrial_ci/ros_pre-release.sh
@@ -29,7 +29,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
-## Author: Isaac I. Y. Saito, Mathias L«ädtke
+## Author: Isaac I. Y. Saito, Mathias LÃ¼dtke
 
 set -e
 set -x
@@ -57,7 +57,7 @@ function setup_docker() {
     sudo -E sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
     sudo -E apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv-key 0xB01FA116
     # Buildfarm workaround for Python3 http://wiki.ros.org/regression_tests#How_do_I_setup_my_system_to_run_a_prerelease.3F
-    sudo -E apt-get update && sudo -E apt-get install python3 python3-pip python-ros-buildfarm
+    sudo -E apt-get update && sudo -E apt-get -qq install -y python3 python3-pip python-ros-buildfarm
     sudo python3 -m pip install -U EmPy
 }
 


### PR DESCRIPTION
Since kinetic tests are run in docker and the prerelease test uses docker as well, this resulted in a docker-in-docker configuration that did not work.

First I tried to make docker-in-docker work with travis, but I had to modify the xenial container a lot because of non-root user issues.

The simpler solution was to not run the prerelease test within docker.
(ros-jade-catkin must be installed for `catkin_test_results` in kinetic test)

Before: https://travis-ci.org/ros-industrial/ros_canopen/builds/184098605
After: https://travis-ci.org/ros-industrial/ros_canopen/builds/184216135