### PR TITLE
Abort rosdep-install.sh on error

### DIFF
--- a/industrial_ci/rosdep-install.sh
+++ b/industrial_ci/rosdep-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash -ex
 
 # Software License Agreement (BSD License)
 #


### PR DESCRIPTION
This patch forces rosdep-install.sh to exit on errors.
Without -e the script exit code was taken from the manifest handling code.
(https://github.com/ros-industrial/universal_robot/pull/277#issuecomment-269709029) 