### PR TITLE
Speedup tests

### DIFF
--- a/.ci.rosinstall.jade
+++ b/.ci.rosinstall.jade
@@ -1,4 +1,3 @@
 - git:
-    uri: https://github.com/ros-industrial/industrial_core.git
-    local-name: ros-industrial/industrial_core
-    version: jade
+    uri: https://github.com/ros/actionlib.git
+    local-name: ros/actionlib

--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -1,6 +1,3 @@
 - git:
-    uri: https://github.com/ros-industrial/industrial_core.git
-    local-name: ros-industrial/industrial_core
-- git:
-    uri: https://github.com/ros-industrial/ros_canopen.git
-    local-name: ros-industrial/ros_canopen
+    uri: https://github.com/ros/std_msgs.git
+    local-name: ros/std_msgs

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
     - ROS_DISTRO=indigo USE_DEVEL_SPACE='true' NOT_TEST_INSTALL='true'  # Expecting no testing to happen during install.
     - ROS_DISTRO=indigo CATKIN_PARALLEL_JOBS='-p1' ROS_PARALLEL_JOBS='-j1'  # Intend build on low-power platform
     # - env: ROS_DISTRO=indigo PRERELEASE=true  ## Comment out because this is meaningless for always failing without prerelease testable contents in industrial_ci.
-    - ROS_DISTRO=indigo PRERELEASE=true PRERELEASE_REPONAME=industrial_core PRERELEASE_DOWNSTREAM_DEPTH=0
+    - ROS_DISTRO=indigo PRERELEASE=true PRERELEASE_REPONAME=std_msgs PRERELEASE_DOWNSTREAM_DEPTH=0
     - ROS_DISTRO=kinetic PRERELEASE=true PRERELEASE_REPONAME=std_msgs
     - ROS_DISTRO=indigo APTKEY_STORE_SKS=hkp://ha.pool.sks-keyservers.vet  # Passing wrong SKS URL as a break test. Should still pass.
     - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=debian
@@ -42,16 +42,15 @@ env:
     - ROS_DISTRO=indigo ADDITIONAL_DEBS="ros-hydro-opencv3" DEBUG_BASH='false' # This should fail (trying from a wrong distro).
     - ROS_DISTRO=jade   APTKEY_STORE_SKS=hkp://ha.pool.sks-keyservers.vet  # Passing wrong SKS URL as a break test. Should still pass.
     - ROS_DISTRO=jade   UPSTREAM_WORKSPACE=file  ROSINSTALL_FILENAME=.ci.rosinstall  # Testing arbitrary file name without ROS_DISTRO suffix. As of 6/3/2016 this fails due to https://github.com/ros-industrial/industrial_core/pull/144#issuecomment-223186764
-    - ROS_DISTRO=jade   PRERELEASE=true PRERELEASE_REPONAME=warehouse_ros PRERELEASE_DOWNSTREAM_DEPTH=1  # Intended to fail (as of Apr 2016), to test the capability of capturing Prerelease Test failure.
+    - ROS_DISTRO=jade   PRERELEASE=true PRERELEASE_REPONAME=i_do_not_exist PRERELEASE_DOWNSTREAM_DEPTH=1  # Intended to fail, to test the capability of capturing Prerelease Test failure.
     - ROS_DISTRO=kinetic
     - ROS_DISTRO=kinetic NOT_TEST_BUILD='true' DEBUG_BASH='false' VERBOSE_OUTPUT='false'
 matrix:
   allow_failures:
     - env: ROS_DISTRO=indigo NOT_TEST_BUILD='true' NOT_TEST_INSTALL='true' POST_PROCESS='I_am_supposed_to_fail'
-    - env: ROS_DISTRO=indigo PRERELEASE=true PRERELEASE_REPONAME=industrial_core PRERELEASE_DOWNSTREAM_DEPTH=0
     - env: ROS_DISTRO=indigo UPSTREAM_WORKSPACE=file USE_DEB=true  # Expected to fail. See https://github.com/ros-industrial/industrial_ci/pull/74
     - env: ROS_DISTRO=indigo ADDITIONAL_DEBS="ros-hydro-opencv3" DEBUG_BASH='false' # This should fail (trying from a wrong distro).
-    - env: ROS_DISTRO=jade   PRERELEASE=true PRERELEASE_REPONAME=warehouse_ros PRERELEASE_DOWNSTREAM_DEPTH=1  # Intended to fail (as of Apr 2016), to test the capability of capturing Prerelease Test failure.
+    - env: ROS_DISTRO=jade   PRERELEASE=true PRERELEASE_REPONAME=i_do_not_exist PRERELEASE_DOWNSTREAM_DEPTH=1  # Intended to fail (as of Apr 2016), to test the capability of capturing Prerelease Test failure.
     - env: ROS_DISTRO=jade   UPSTREAM_WORKSPACE=file  ROSINSTALL_FILENAME=.ci.rosinstall
 
 before_script:

--- a/industrial_ci/Dockerfile
+++ b/industrial_ci/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER "ROS Industrial" "https://github.com/ros-industrial"
 
 # Install packages
 RUN apt-get update -qq \
-    && apt-get -qq install -y \
+    && apt-get -qq install --no-install-recommends -y \
         git \
         sudo \
         lsb-release \


### PR DESCRIPTION
This PR simplifies the test candidates to ultra stable packages with only few dependencies.
Test job duration will decrease from >1h to ~15 minutes.

Please note: The travis job for this PR will take about 20 minutes because job ~~15~~16 still uses the rosinstall file from the master branch.
