### PR TITLE
Add maintainer

### DIFF
--- a/industrial_ci/package.xml
+++ b/industrial_ci/package.xml
@@ -4,7 +4,9 @@
   <description>common travis script suite</description>
   <license>BSD</license>
   <maintainer email="iisaito@kinugarage.com">Isaac I. Y. Saito</maintainer>
-  <author email="iiysaito@opensource-robotics.tokyo.jp">Isaac I. Y. Saito</author>
+  <maintainer email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</maintainer>
+  <author>Isaac I. Y. Saito</author>
+  <author email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 


### PR DESCRIPTION
<s>See https://github.com/ros-industrial/industrial_ci/pull/101#issuecomment-272899368
I'm adding back `industrial_core` to a job that uses .rosinstall file on Kinetic. Rationale:
- Now that `industrial_core` is released into Kinetic. Kinetic will be maintained longer, and we want more Kinetic samples.
- It's allow_failure so that if in hurry we can<s>'t</s> still ignore this particular job.
</s>

Also added is the maintainer addition (picked from https://github.com/ros-industrial/industrial_ci/pull/86#issuecomment-268507950, which needs reconsideration and therefore on a hiatus now).