### PR TITLE
fix unset of TRAVIS_FOLD_NAME

### DIFF
--- a/industrial_ci/util.sh
+++ b/industrial_ci/util.sh
@@ -85,7 +85,7 @@ function ici_time_end {
     echo -e "ici_fold:end:$TRAVIS_FOLD_NAME\e[${color_wrap}m<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\e[0m"
     echo -e "\e[0K\e[${color_wrap}mFunction $TRAVIS_FOLD_NAME returned with code '${exit_code}' after $(( $TIME_ELAPSED_SECONDS / 60 )) min $(( $TIME_ELAPSED_SECONDS % 60 )) sec \e[0m"
 
-    unset $TRAVIS_FOLD_NAME
+    unset TRAVIS_FOLD_NAME
     if [ "$DEBUG_BASH" ] && [ "$DEBUG_BASH" == true ]; then set -x; fi
 }
 


### PR DESCRIPTION
Current master leads to doubled `after_script` fold closings because `TRAVIS_FOLD_NAME` is not unset properly.