### PR TITLE
remove unused compiler settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ sudo: required
 dist: trusty
 # Force travis to use its minimal image with default Python settings
 language: generic
-compiler:
-  - gcc
 notifications:
   #  Whoever receives success and/or failure via email
   email:


### PR DESCRIPTION
travis-lint:
`specified compiler, but setting is not relevant for generic`

@ipa-bnm: FYI 