### PR TITLE
[ROS Lunar] Use mockups pkg as a smoke test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ env:
     - ROS_DISTRO=kinetic OS_NAME=debian OS_CODE_NAME=xenial EXPECT_EXIT_CODE=1
     - ROS_DISTRO=kinetic NOT_TEST_BUILD='true' DEBUG_BASH='true' VERBOSE_OUTPUT='false'
     - ROS_DISTRO=kinetic APTKEY_STORE_SKS=hkp://ha.pool.sks-keyservers.vet  # Passing wrong SKS URL as a break test. Should still pass.
-    - ROS_DISTRO=lunar ROS_REPO=ros-shadow-fixed
+    - ROS_DISTRO=lunar ROS_REPO=ros-shadow-fixed USE_MOCKUP='industrial_ci/mockups/industrial_ci_testpkg'
 matrix:
   allow_failures:
     - env: ROS_DISTRO=indigo NOT_TEST_BUILD='true' NOT_TEST_INSTALL='true' POST_PROCESS='I_am_supposed_to_fail'

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     - BEFORE_SCRIPT='echo current dir: $(pwd)'
 
   matrix:
-    - ROS_DISTRO=hydro
+    - ROS_DISTRO=hydro  USE_MOCKUP='industrial_ci/mockups/industrial_ci_testpkg'
     - ROS_DISTRO=indigo USE_MOCKUP='industrial_ci/mockups/industrial_ci_testpkg'
     - ROS_DISTRO=indigo USE_MOCKUP='industrial_ci/mockups/industrial_ci_testpkg' ROSDEP_SKIP_KEYS="rospy_tutorials rostest" EXPECT_EXIT_CODE=1
     - ROS_DISTRO=indigo USE_MOCKUP='industrial_ci/mockups/testpkg_broken_install'  EXPECT_EXIT_CODE=1


### PR DESCRIPTION
<s>**DO NOT MERGE YET** - this should be mergeable once core packages of ROS Lunar become available (so maybe when https://github.com/ros/rosdistro/issues/13550 gets closed).</s> -> Condition cleared.

This addresses the concern raised at https://github.com/ros-industrial/industrial_ci/pull/131#issuecomment-281162743

> The [`lunar` job](https://travis-ci.org/ros-industrial/industrial_ci/jobs/203429152) passing already doesn't make sense to me, when there are only a couple of packages (I forgot what they were back then. Today more core packages have been already [released](http://repositories.ros.org/status_page/ros_lunar_default.html))?

Looking at the commit history at [rosdistro/lunar/distribution.yaml](https://github.com/ros/rosdistro/commits/master/lunar/distribution.yaml) the two packages that were available for Lunar at the time of https://github.com/ros-industrial/industrial_ci/pull/131#issuecomment-281162743 were `catkin` and `gencpp`, which are not sufficient for any catkin package to pass the test IMO. So any Lunar test should've failed, but due to the lack of testing, it passed.

Using `industrial_ci_testpkg` for the test should address the situation.