### PR TITLE
build directly to install space

### DIFF
--- a/industrial_ci/src/tests/source_tests.sh
+++ b/industrial_ci/src/tests/source_tests.sh
@@ -154,7 +154,7 @@ if [ "$NOT_TEST_INSTALL" != "true" ]; then
 
     ici_time_start catkin_install_run_tests
 
-    export EXIT_STATUS=0
+    EXIT_STATUS=0
     # Test if the unit tests in the packages in the downstream repo pass.
     if [ "$BUILDER" == catkin ]; then
       for pkg in $PKGS_DOWNSTREAM; do
@@ -163,8 +163,8 @@ if [ "$NOT_TEST_INSTALL" != "true" ]; then
         echo "[$pkg] Found $(echo $rostest_files | wc -w) tests."
         for test_file in $rostest_files; do
           echo "[$pkg] Testing $test_file"
-          $CATKIN_WORKSPACE/install/env.sh rostest $test_file || export EXIT_STATUS=$?
-          if [ $? != 0 ]; then
+          $CATKIN_WORKSPACE/install/env.sh rostest $test_file || EXIT_STATUS=$?
+          if [ $EXIT_STATUS != 0 ]; then
             echo -e "[$pkg] Testing again the failed test: $test_file.\e[31m>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\e[0m"
             $CATKIN_WORKSPACE/install/env.sh rostest --text $test_file
             echo -e "[$pkg] Testing again the failed test: $test_file.\e[31m<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\e[0m"

--- a/industrial_ci/src/tests/source_tests.sh
+++ b/industrial_ci/src/tests/source_tests.sh
@@ -141,7 +141,6 @@ if [ "$NOT_TEST_BUILD" != "true" ]; then
     ici_time_start catkin_run_tests
 
     if [ "$BUILDER" == catkin ]; then
-        source $CATKIN_WORKSPACE/devel/setup.bash # force to update ROS_PACKAGE_PATH for rostest
         catkin run_tests $OPT_VI --no-deps --no-status $PKGS_DOWNSTREAM $CATKIN_PARALLEL_TEST_JOBS --make-args $ROS_PARALLEL_TEST_JOBS --
         catkin_test_results $CATKIN_WORKSPACE || error
     fi

--- a/industrial_ci/src/tests/source_tests.sh
+++ b/industrial_ci/src/tests/source_tests.sh
@@ -149,7 +149,6 @@ if [ "$NOT_TEST_BUILD" != "true" ]; then
     ici_time_end  # catkin_run_tests
 fi
 
-
 if [ "$NOT_TEST_INSTALL" != "true" ]; then
 
     ici_time_start catkin_install_run_tests
@@ -158,8 +157,10 @@ if [ "$NOT_TEST_INSTALL" != "true" ]; then
     # Test if the unit tests in the packages in the downstream repo pass.
     if [ "$BUILDER" == catkin ]; then
       for pkg in $PKGS_DOWNSTREAM; do
+        if [ ! -d "$CATKIN_WORKSPACE/install/share/$pkg" ]; then continue; fi # skip meta-packages
+
         echo "[$pkg] Started testing..."
-        rostest_files=$(find "$CATKIN_WORKSPACE/install/share/$pkg" -iname '*.test') || continue # metapackage do not install anything in share
+        rostest_files=$(find "$CATKIN_WORKSPACE/install/share/$pkg" -iname '*.test')
         echo "[$pkg] Found $(echo $rostest_files | wc -w) tests."
         for test_file in $rostest_files; do
           echo "[$pkg] Testing $test_file"


### PR DESCRIPTION
This PR picks some install space related commits from #137
The current master (still) builds all packages, cleans and rebuild to install space (unless `NOT_TEST_INSTALL=true).

These patches avoid rebuilding and fix the retry behavior.