### PR TITLE
Silence rosdep

### DIFF
--- a/industrial_ci/src/docker.env
+++ b/industrial_ci/src/docker.env
@@ -10,6 +10,7 @@ CATKIN_TEST_RESULTS_CMD
 DEBUG_BASH
 # EXPECT_EXIT_CODE, do not pass to make sure code is checked on the outer level only
 IN_DOCKER=true
+LC_ALL=C.UTF-8
 NOT_TEST_BUILD
 NOT_TEST_INSTALL
 PKGS_DOWNSTREAM

--- a/industrial_ci/src/tests/source_tests.sh
+++ b/industrial_ci/src/tests/source_tests.sh
@@ -117,7 +117,10 @@ fi
 
 ici_time_start rosdep_install
 
-rosdep install -q --from-paths $CATKIN_WORKSPACE --ignore-src --rosdistro $ROS_DISTRO -y
+set -o pipefail # fail if rosdep install fails
+rosdep install -q --from-paths $CATKIN_WORKSPACE --ignore-src --rosdistro $ROS_DISTRO -y | { grep "executing command" || true; }
+set +o pipefail
+
 ici_time_end  # rosdep_install
 
 function catkin {


### PR DESCRIPTION
Filters most of the rosdep install output, just prints commands and errors.
closes #141