### PR TITLE
install most recommends in base image

### DIFF
--- a/industrial_ci/src/docker.sh
+++ b/industrial_ci/src/docker.sh
@@ -157,7 +157,7 @@ function ici_build_default_docker_image() {
   ici_docker_build - <<EOF > /dev/null
 FROM ubuntu:$UBUNTU_OS_CODE_NAME
 
-RUN apt-get update -qq && apt-get -qq install --no-install-recommends -y wget ca-certificates
+RUN apt-get update -qq && apt-get -qq install -y wget ca-certificates
 
 RUN echo "deb ${ROS_REPOSITORY_PATH} $UBUNTU_OS_CODE_NAME main" > /etc/apt/sources.list.d/ros-latest.list
 RUN apt-key adv --keyserver "${APTKEY_STORE_SKS}" --recv-key "${HASHKEY_SKS}" \
@@ -165,15 +165,16 @@ RUN apt-key adv --keyserver "${APTKEY_STORE_SKS}" --recv-key "${HASHKEY_SKS}" \
 
 RUN sed -i "/^# deb.*multiverse/ s/^# //" /etc/apt/sources.list \
     && apt-get update -qq \
-    && apt-get -qq install --no-install-recommends -y \
+    && apt-get -qq install -y \
         build-essential \
         python-catkin-tools \
         python-pip \
         python-rosdep \
-        python-wstool \
         ros-$ROS_DISTRO-catkin \
-        ssh-client \
         sudo \
+    && apt-get -qq install --no-install-recommends -y \
+        python-wstool \
+        ssh-client \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 EOF


### PR DESCRIPTION
This patch installs all recommended packages, mostly for pip.
As a trade-off the wstool dependencies got stripped.

It adds 20s to each build job, but ensures that all/most pip packages could be installed.
I am not sure if we really should merge this.
Perhaps we shoud not install recommended packages, but add `python-dev` to our list.

For kinetic the following packages get installed additionally (249->298):
```
docutils-doc/now 0.12+dfsg-1 all [installed,local]
fakeroot/now 1.20.2-1ubuntu1 amd64 [installed,local]
file/now 1:5.25-2ubuntu1 amd64 [installed,local]
ifupdown/now 0.8.10ubuntu1.2 amd64 [installed,local]
iproute2/now 4.3.0-1ubuntu3 amd64 [installed,local]
isc-dhcp-client/now 4.3.3-5ubuntu12.6 amd64 [installed,local]
isc-dhcp-common/now 4.3.3-5ubuntu12.6 amd64 [installed,local]
javascript-common/now 11 all [installed,local]
krb5-locales/now 1.13.2+dfsg-5ubuntu2 all [installed,local]
libalgorithm-diff-perl/now 1.19.03-1 all [installed,local]
libalgorithm-diff-xs-perl/now 0.04-4build1 amd64 [installed,local]
libalgorithm-merge-perl/now 0.08-3 all [installed,local]
libatm1/now 1:2.5.1-1.5 amd64 [installed,local]
libdns-export162/now 1:9.10.3.dfsg.P4-8ubuntu1.5 amd64 [installed,local]
libexpat1-dev/now 2.1.0-7ubuntu0.16.04.2 amd64 [installed,local]
libfakeroot/now 1.20.2-1ubuntu1 amd64 [installed,local]
libfile-fcntllock-perl/now 0.22-3 amd64 [installed,local]
libfreetype6/now 2.6.1-0.1ubuntu2.1 amd64 [installed,local]
libisc-export160/now 1:9.10.3.dfsg.P4-8ubuntu1.5 amd64 [installed,local]
libjbig0/now 2.1-3.1 amd64 [installed,local]
libjpeg8/now 8c-2ubuntu8 amd64 [installed,local]
libjpeg-turbo8/now 1.4.2-0ubuntu3 amd64 [installed,local]
liblcms2-2/now 2.6-3ubuntu2 amd64 [installed,local]
libmagic1/now 1:5.25-2ubuntu1 amd64 [installed,local]
libmnl0/now 1.0.3-5 amd64 [installed,local]
libpaper1/now 1.1.24+nmu4ubuntu1 amd64 [installed,local]
libpaper-utils/now 1.1.24+nmu4ubuntu1 amd64 [installed,local]
libpng12-0/now 1.2.54-1ubuntu1 amd64 [installed,local]
libpython2.7-dev/now 2.7.12-1ubuntu0~16.04.1 amd64 [installed,local]
libpython2.7/now 2.7.12-1ubuntu0~16.04.1 amd64 [installed,local]
libpython-all-dev/now 2.7.11-1 amd64 [installed,local]
libpython-dev/now 2.7.11-1 amd64 [installed,local]
libsasl2-modules/now 2.1.26.dfsg1-14build1 amd64 [installed,local]
libtiff5/now 4.0.6-1ubuntu0.1 amd64 [installed,local]
libwebp5/now 0.4.4-1 amd64 [installed,local]
libwebpmux1/now 0.4.4-1 amd64 [installed,local]
libxtables11/now 1.6.0-2ubuntu3 amd64 [installed,local]
manpages-dev/now 4.04-2 all [installed,local]
manpages/now 4.04-2 all [installed,local]
netbase/now 5.3 all [installed,local]
python2.7-dev/now 2.7.12-1ubuntu0~16.04.1 amd64 [installed,local]
python-all-dev/now 2.7.11-1 amd64 [installed,local]
python-all/now 2.7.11-1 amd64 [installed,local]
python-chardet/now 2.3.0-2 all [installed,local]
python-dev/now 2.7.11-1 amd64 [installed,local]
python-pil/now 3.1.2-0ubuntu1.1 amd64 [installed,local]
python-pygments/now 2.1+dfsg-1 all [installed,local]
python-wheel/now 0.29.0-1 all [installed,local]
rename/now 0.20-4 all [installed,local]
```