### PR TITLE
added generic ci.sh

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -16,12 +16,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This is the entrypoint for Travis CI only.
+# This is the generic entrypoint for CI services.
 
 # 2016/05/18 http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
 DIR_THIS="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-export TARGET_REPO_PATH=$TRAVIS_BUILD_DIR
-export TARGET_REPO_NAME=${TRAVIS_REPO_SLUG##*/}
+export TARGET_REPO_PATH=${TARGET_REPO_PATH:-$(pwd)}
+export TARGET_REPO_NAME=${TARGET_REPO_NAME:-${TARGET_REPO_PATH##*/}}
+export _DO_NOT_FOLD=${_DO_NOT_FOLD:-true}
 
 env "$@" bash $DIR_THIS/industrial_ci/src/ci_main.sh

--- a/gitlab.sh
+++ b/gitlab.sh
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file remains as "travis.sh" at the top directory of industrial_ci repository only to keep backward compatibility between version 0.2.2 and the newer.
+# This is the entrypoint for Gitlab CI only.
 
 # 2016/05/18 http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
 DIR_THIS="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/industrial_ci/scripts/run_ci
+++ b/industrial_ci/scripts/run_ci
@@ -42,8 +42,7 @@ else
     ci_dir=$(python2 -c "import rospkg; print rospkg.RosPack().get_path('industrial_ci')" 2>/dev/null) || { echo "could not find ci_main.sh"; exit 1; }
 fi
 
-cd "$ci_dir/src"
-env "$@" /bin/bash ci_main.sh
+env "$@" /bin/bash "$ci_dir/src/ci_main.sh"
 ret=$?
 
 if [ "$ret" == "0" ]; then


### PR DESCRIPTION
as discussed in #157 

This introduces a generic `ci.sh` as suggested by @inigomartinez.
If `TARGET_REPO_PATH` and/or `TARGET_REPO_NAME` are not set, the current working directoy is used.
In contrast `travis.sh` does not use the working directory anymore, but reads the `TRAVIS*` variables instead.