### PR TITLE
Handle problems with the xenial docker image

### DIFF
--- a/industrial_ci/src/docker.sh
+++ b/industrial_ci/src/docker.sh
@@ -162,7 +162,9 @@ function ici_build_default_docker_image() {
   ici_docker_build - <<EOF > /dev/null
 FROM ubuntu:$UBUNTU_OS_CODE_NAME
 
-RUN apt-get update -qq && apt-get -qq install --no-install-recommends -y wget ca-certificates sudo
+RUN apt-get update -qq \
+    && apt-get -qq install --no-install-recommends -y apt-utils \
+    && apt-get -qq install --no-install-recommends -y wget ca-certificates sudo
 
 RUN echo "deb ${ROS_REPOSITORY_PATH} $UBUNTU_OS_CODE_NAME main" > /etc/apt/sources.list.d/ros-latest.list
 RUN apt-key adv --keyserver "${APTKEY_STORE_SKS}" --recv-key "${HASHKEY_SKS}" \

--- a/industrial_ci/src/docker.sh
+++ b/industrial_ci/src/docker.sh
@@ -165,8 +165,7 @@ FROM ubuntu:$UBUNTU_OS_CODE_NAME
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
 RUN apt-get update -qq \
-    && apt-get -qq install --no-install-recommends -y apt-utils \
-    && apt-get -qq install --no-install-recommends -y wget ca-certificates sudo
+    && apt-get -qq install --no-install-recommends -y apt-utils wget ca-certificates sudo
 
 RUN echo "deb ${ROS_REPOSITORY_PATH} $UBUNTU_OS_CODE_NAME main" > /etc/apt/sources.list.d/ros-latest.list
 RUN apt-key adv --keyserver "${APTKEY_STORE_SKS}" --recv-key "${HASHKEY_SKS}" \

--- a/industrial_ci/src/docker.sh
+++ b/industrial_ci/src/docker.sh
@@ -162,6 +162,8 @@ function ici_build_default_docker_image() {
   ici_docker_build - <<EOF > /dev/null
 FROM ubuntu:$UBUNTU_OS_CODE_NAME
 
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
 RUN apt-get update -qq \
     && apt-get -qq install --no-install-recommends -y apt-utils \
     && apt-get -qq install --no-install-recommends -y wget ca-certificates sudo


### PR DESCRIPTION
Xenial docker image does not come with apt-utils installed, which leads to several warning messages:
`debconf: delaying package configuration, since apt-utils is not installed`
This also highly delays the creation of the docker container.

Second problem shows this error/warning message:
```
++ rosdep install -q --from-paths /root/catkin_ws --ignore-src --rosdistro kinetic -y
++ grep 'executing command'
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 132.)
debconf: falling back to frontend: Readline
```
