### PR TITLE
use zesty for lunar tests

### DIFF
--- a/industrial_ci/src/env.sh
+++ b/industrial_ci/src/env.sh
@@ -65,8 +65,11 @@ if [ -z "$UBUNTU_OS_CODE_NAME" ]; then
     "indigo"|"jade")
         UBUNTU_OS_CODE_NAME="trusty"
         ;;
-    "kinetic"|"lunar")
+    "kinetic")
         UBUNTU_OS_CODE_NAME="xenial"
+        ;;
+    "lunar")
+        UBUNTU_OS_CODE_NAME="zesty"
         ;;
     *)
         error "ROS distro '$ROS_DISTRO' is not supported"


### PR DESCRIPTION
Some code can be built for xenial, but not for zesty, e.g. because of the c++11 compiler.
This fix uses zesty for lunar tests instead of xenial per default.
