### PR TITLE
test external projects again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,10 @@ env:
     - ROS_DISTRO=kinetic NOT_TEST_BUILD='true' DEBUG_BASH='true' VERBOSE_OUTPUT='false'
     - ROS_DISTRO=kinetic APTKEY_STORE_SKS=hkp://ha.pool.sks-keyservers.vet  # Passing wrong SKS URL as a break test. Should still pass.
     - ROS_DISTRO=lunar ROS_REPO=ros-shadow-fixed USE_MOCKUP='industrial_ci/mockups/industrial_ci_testpkg'
+    - ROS_DISTRO=kinetic _EXTERNAL_REPO='ros-industrial/industrial_core#kinetic-devel'
+    - ROS_DISTRO=kinetic _EXTERNAL_REPO='ros-industrial/motoman_experimental#kinetic-devel' UPSTREAM_WORKSPACE=file BEFORE_SCRIPT='touch $CATKIN_WORKSPACE/src/ros-industrial/industrial_experimental/IRC_v2/CATKIN_IGNORE'
+    - ROS_DISTRO=kinetic _EXTERNAL_REPO='ros-controls/ros_control#kinetic-devel' UPSTREAM_WORKSPACE=file ROSINSTALL_FILENAME=ros_control.rosinstall ROS_PARALLEL_TEST_JOBS=-j1
+    - ROS_DISTRO=kinetic _EXTERNAL_REPO='ipa320/cob_calibration_data#indigo_dev' ROS_REPO=ros UPSTREAM_WORKSPACE=file AFTER_SCRIPT='./.travis.xacro_test.sh'
 matrix:
   allow_failures:
     - env: ROS_DISTRO=indigo NOT_TEST_BUILD='true' NOT_TEST_INSTALL='true' POST_PROCESS='I_am_supposed_to_fail'

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,10 +65,6 @@ matrix:
     - env: ROS_DISTRO=jade   UPSTREAM_WORKSPACE=file  ROSINSTALL_FILENAME=.ci.rosinstall
 
 before_script:
-  - CI_DIR=.
-  - if [ "${USE_CATKIN_MAKE}" == "true" ] ;then sed -i 's@catkin build -i -v --limit-status-rate 0.001@catkin_make@' $CI_DIR/travis.sh; fi
-  - if [ "${USE_CATKIN_MAKE}" == "true" ] ;then sed -i 's@catkin run_tests --no-deps --limit-status-rate 0.001@catkin_make run_tests@' $CI_DIR/travis.sh; fi
-  - if [ "${USE_CATKIN_MAKE}" == "true" ] ;then export CATKIN_PARALLEL_JOBS="--no-color" ; fi
 script:
-  - $CI_DIR/travis.sh
+  - industrial_ci/_wrap_test.sh # this script is only for internal use
   - if ! [ -z "$POST_PROCESS" ]; then $POST_PROCESS; fi

--- a/industrial_ci/_wrap_test.sh
+++ b/industrial_ci/_wrap_test.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Copyright (c) 2017, Mathias Lüdtke
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is the internal entrypoint for industrial_ci testing
+
+set -e # exit script on errors
+
+if [ -n "$_EXTERNAL_REPO" ]; then
+
+    export TRAVIS_BUILD_DIR=$(mktemp -d)
+
+    repo_name=${_EXTERNAL_REPO%%#*}
+    repo_branch=${_EXTERNAL_REPO##*#}
+
+    if [ "$repo_branch" != "$repo_url" ]; then # if branch name was provided
+        clone_opts="-b $repo_branch"
+    fi
+
+    if [[ "$repo_name" =~ ^[a-zA-Z][\w+-\.]*: ]]; then # stars with scheme (RFC 3986)
+        repo_url=$repo_name
+    else
+        repo_url="https://github.com/$repo_name.git" # treat as github repo
+    fi
+
+    git clone "$repo_url" -b "${_EXTERNAL_REPO##*#}" "$TRAVIS_BUILD_DIR"
+    urlbasename=${repo_url##*/}
+    urldirname=${repo_url%/$urlbasename}
+    export TRAVIS_REPO_SLUG="${urldirname##*/}/${urlbasename%.git}"
+fi
+
+./travis.sh


### PR DESCRIPTION
This PR introduces a new feature for internal-use.
it can be used to run `industrial_ci` for external repositories, just as travis would do.
That's why I have introduced an internal script `_wrap_test.sh`.

@Jmeyer1292, @shaun-edwards, @gavanderhoorn, @ipa-fxm, @130s: Do you have some suggestions for other candidates?
In the end it should be a nice mix of ~5 external repos.


