### PR TITLE
Pass subversion credentials from host to docker container.

### DIFF
--- a/industrial_ci/src/docker.sh
+++ b/industrial_ci/src/docker.sh
@@ -79,6 +79,9 @@ function ici_run_cmd_in_docker() {
   if [ -d ~/.ssh ]; then
     docker cp ~/.ssh "$cid:/root/" # pass SSH settings to container
   fi
+  if [ -d ~/.subversion ]; then
+    docker cp ~/.subversion "$cid:/root/" # pass svn auth to container
+  fi
 
   docker start -a "$cid" &
   trap 'docker kill $cid' INT


### PR DESCRIPTION
Installing the dependencies of the package using rosinstall might require to access a subversion repository. We copy the ~/.subversion folder to the docker container to copy the authorization when connecting directly to the subversion server (not through ssh).