### PR TITLE
don't deduce OS names from DOCKER_BASE_IMAGE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
     - ROS_DISTRO=indigo NOT_TEST_BUILD='true' NOT_TEST_INSTALL='true' POST_PROCESS='I_am_supposed_to_fail'
     - ROS_DISTRO=indigo CATKIN_PARALLEL_JOBS='-p1' ROS_PARALLEL_JOBS='-j1'  # Intend build on low-power platform
     # - env: ROS_DISTRO=indigo PRERELEASE=true  ## Comment out because this is meaningless for always failing without prerelease testable contents in industrial_ci.
-    - ROS_DISTRO=indigo PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=1
+    - ROS_DISTRO=indigo PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=1 DOCKER_BASE_IMAGE=something
     - ROS_DISTRO=indigo PRERELEASE=true USE_MOCKUP='industrial_ci/mockups/failing_test' EXPECT_EXIT_CODE=1
     - ROS_DISTRO=kinetic PRERELEASE=true PRERELEASE_REPONAME=industrial_ci
     - ROS_DISTRO=indigo APTKEY_STORE_SKS=hkp://ha.pool.sks-keyservers.vet  # Passing wrong SKS URL as a break test. Should still pass.
@@ -55,7 +55,7 @@ env:
     - ROS_DISTRO=kinetic OS_NAME=debian OS_CODE_NAME=jessie AFTER_SCRIPT='grep -q ID=debian /etc/os-release && grep -q VERSION_ID=\"8\" /etc/os-release'
     - ROS_DISTRO=kinetic OS_NAME=debian EXPECT_EXIT_CODE=1
     - ROS_DISTRO=kinetic OS_NAME=debian OS_CODE_NAME=xenial EXPECT_EXIT_CODE=1
-    - ROS_DISTRO=kinetic NOT_TEST_BUILD='true' DEBUG_BASH='true' VERBOSE_OUTPUT='false'
+    - ROS_DISTRO=kinetic DOCKER_BASE_IMAGE="ros:kinetic-ros-base" NOT_TEST_BUILD='true' DEBUG_BASH='true' VERBOSE_OUTPUT='false'
     - ROS_DISTRO=kinetic APTKEY_STORE_SKS=hkp://ha.pool.sks-keyservers.vet  # Passing wrong SKS URL as a break test. Should still pass.
     - ROS_DISTRO=lunar ROS_REPO=ros-shadow-fixed USE_MOCKUP='industrial_ci/mockups/industrial_ci_testpkg'
     - ROS_DISTRO=kinetic _EXTERNAL_REPO='ros-industrial/industrial_core#kinetic-devel'

--- a/industrial_ci/src/docker.sh
+++ b/industrial_ci/src/docker.sh
@@ -15,6 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# docker.sh script sets up Docker image.
+# It is dependent on environment variables that need to be exported in advance
+# (As of version 0.4.4 most of them are defined in ./env.sh).
+
 #######################################
 # rerun the CI script in docker container end exit the outer script
 #

--- a/industrial_ci/src/docker.sh
+++ b/industrial_ci/src/docker.sh
@@ -163,7 +163,8 @@ function ici_prepare_docker_image() {
 #   (None)
 
 function ici_build_default_docker_image() {
-  export DOCKER_IMAGE="industrial-ci/$OS_CODE_NAME"
+  # choose a unique image name
+  export DOCKER_IMAGE="industrial-ci/$ROS_DISTRO/$DOCKER_BASE_IMAGE"
   ici_generate_default_dockerfile | ici_docker_build - > /dev/null
 }
 
@@ -174,9 +175,9 @@ FROM $DOCKER_BASE_IMAGE
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
 RUN apt-get update -qq \
-    && apt-get -qq install --no-install-recommends -y apt-utils gnupg wget ca-certificates sudo
+    && apt-get -qq install --no-install-recommends -y apt-utils gnupg wget ca-certificates sudo lsb-release
 
-RUN echo "deb ${ROS_REPOSITORY_PATH} ${OS_CODE_NAME} main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb ${ROS_REPOSITORY_PATH} \$(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list
 RUN apt-key adv --keyserver "${APTKEY_STORE_SKS}" --recv-key "${HASHKEY_SKS}" \
     || { wget "${APTKEY_STORE_HTTPS}" -O - | sudo apt-key add -; }
 

--- a/industrial_ci/src/docker.sh
+++ b/industrial_ci/src/docker.sh
@@ -169,7 +169,10 @@ function ici_prepare_docker_image() {
 function ici_build_default_docker_image() {
   # choose a unique image name
   export DOCKER_IMAGE="industrial-ci/$ROS_DISTRO/$DOCKER_BASE_IMAGE"
-  ici_generate_default_dockerfile | ici_docker_build - > /dev/null
+  echo "Building image '$DOCKER_IMAGE':"
+  local dockerfile=$(ici_generate_default_dockerfile)
+  echo "$dockerfile"
+  ici_docker_build - <<< "$dockerfile" > /dev/null
 }
 
 function ici_generate_default_dockerfile() {

--- a/industrial_ci/src/env.sh
+++ b/industrial_ci/src/env.sh
@@ -63,38 +63,36 @@ export OS_CODE_NAME
 export OS_NAME
 export DOCKER_BASE_IMAGE
 
-# exit with error if OS_NAME is set, but OS_CODE_NAME is not
-if [ -n "$OS_NAME" ] && [ -z "$OS_CODE_NAME" ]; then
+# exit with error if OS_NAME is set, but OS_CODE_NAME is not.
+# assume ubuntu as default
+if [ -z "$OS_NAME" ]; then
+    OS_NAME=ubuntu
+elif [ -z "$OS_CODE_NAME" ]; then
     error "please specify OS_CODE_NAME"
 fi
 
 if [ -n "$UBUNTU_OS_CODE_NAME" ]; then # for backward-compatibility
     OS_CODE_NAME=$UBUNTU_OS_CODE_NAME
-    OS_NAME=ubuntu
 fi
 
-if [ -n "$DOCKER_BASE_IMAGE" ]; then
-    # try to guess OS from default image scheme
-    OS_CODE_NAME=${OS_CODE_NAME:-${DOCKER_BASE_IMAGE##*:}} # use tag
-    OS_NAME=${OS_NAME:-${DOCKER_BASE_IMAGE%%:*}} # use repo
-else
-    if [ -z "$OS_CODE_NAME" ]; then
-        case "$ROS_DISTRO" in
-        "hydro")
-            OS_CODE_NAME="precise"
-            ;;
-        "indigo"|"jade")
-            OS_CODE_NAME="trusty"
-            ;;
-        "kinetic"|"lunar")
-            OS_CODE_NAME="xenial"
-            ;;
-        *)
-            error "ROS distro '$ROS_DISTRO' is not supported"
-            ;;
-        esac
-        OS_NAME=ubuntu
-    fi
+if [ -z "$OS_CODE_NAME" ]; then
+    case "$ROS_DISTRO" in
+    "hydro")
+        OS_CODE_NAME="precise"
+        ;;
+    "indigo"|"jade")
+        OS_CODE_NAME="trusty"
+        ;;
+    "kinetic"|"lunar")
+        OS_CODE_NAME="xenial"
+        ;;
+    *)
+        error "ROS distro '$ROS_DISTRO' is not supported"
+        ;;
+    esac
+fi
+
+if [ -z "$DOCKER_BASE_IMAGE" ]; then
     DOCKER_BASE_IMAGE="$OS_NAME:$OS_CODE_NAME" # scheme works for all supported OS images
 fi
 

--- a/industrial_ci/src/tests/ros_prerelease.sh
+++ b/industrial_ci/src/tests/ros_prerelease.sh
@@ -16,6 +16,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# ros_prerelease.sh script runs ROS Pre-release Test.
+# It is dependent on environment variables that need to be exported in advance
+# (As of version 0.4.4 most of them are defined in env.sh).
+
 function setup_environment() {
     export WORKSPACE
     WORKSPACE=$(mktemp -d)

--- a/industrial_ci/src/tests/source_tests.sh
+++ b/industrial_ci/src/tests/source_tests.sh
@@ -18,6 +18,10 @@
 #
 ## Greatly inspired by JSK travis https://github.com/jsk-ros-pkg/jsk_travis
 
+# source_tests.sh script runs integration tests for the target ROS packages.
+# It is dependent on environment variables that need to be exported in advance
+# (As of version 0.4.4 most of them are defined in env.sh).
+
 ici_require_run_in_docker # this script must be run in docker
 
 #Define some verbose env vars


### PR DESCRIPTION
Fixes #197 

This should only affect users that specify `DOCKER_BASE_IMAGE`.
For source tests the codename will be read with `lsb_release`.
For the prelease the codname has to be set explicitly, `OS_NAME` defaults to `ubuntu` for the sake of convenience.

@miguelprada: please test / review.

TODO;
- [x] add tests
- [x] ~~update docs~~
