### PR TITLE
do not run prerelease on gitlab for jade (EOL)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,10 +17,10 @@ indigo:
     ROS_DISTRO: "indigo"
 
 jade:
-  script: .ci_config/gitlab.sh
-  variables:
-    ROS_DISTRO: "jade"
-    PRERELEASE: "true"
+  script: .ci_config/gitlab.sh ROS_DISTRO=jade  # alternate syntax
 
 kinetic:
-  script: .ci_config/gitlab.sh ROS_DISTRO=kinetic # alternate syntax
+  script: .ci_config/gitlab.sh
+  variables:
+    ROS_DISTRO: "kinetic"
+    PRERELEASE: "true"


### PR DESCRIPTION
Prerelease tests for jade are not supported anymore, because it is EOL.
This patch fixes the example to work again.

https://gitlab.com/ipa-mdl/industrial_ci/pipelines/13297557