### PR TITLE
implemented run_travis

### DIFF
--- a/industrial_ci/CMakeLists.txt
+++ b/industrial_ci/CMakeLists.txt
@@ -6,6 +6,8 @@ catkin_package()
 install(PROGRAMS scripts/run_ci
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
        )
+catkin_install_python(PROGRAMS scripts/run_travis
+                      DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 install(DIRECTORY src
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}

--- a/industrial_ci/package.xml
+++ b/industrial_ci/package.xml
@@ -23,6 +23,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <run_depend>python-rospkg</run_depend>
+  <run_depend>python-yaml</run_depend>
 
   <export/>
 </package>

--- a/industrial_ci/scripts/run_travis
+++ b/industrial_ci/scripts/run_travis
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+import os
+import os.path
+import re
+import subprocess
+import sys
+
+import yaml
+
+# find config file either in first argument or curret working directory
+def find_config_file(args, names):
+    def test_file(dir): # test if one of the file names is present
+        for n in  names:
+            p = os.path.join(dir, n)
+            if os.path.isfile(p):
+                return os.path.abspath(p)
+        return None
+
+    if len(args) >  0: # test first argument if available
+        p = test_file(args[0])
+        if p is not None:
+            return p, args[1:]
+    return test_file(os.getcwd()), args
+
+# parse range tuples from arguments
+def parse_ranges(args, offset=0):
+    r = []
+    def apply_offset(i): # adjust for user offsets
+        ao = int(i) + offset
+        if ao < 0:
+            raise ValueError("%s is not in supported range" % str(i))
+        return ao
+
+    for a in args:
+        if '-' in a: # range string
+            p1, p2 = a.split('-', 2)
+            if p1 == '' and len(r) == 0: # -X
+                p1 = 0
+            else: # X-[Y]
+                p1 = apply_offset(p1)
+            if p2 == '': # [X]-
+                r.append((p1, -1))
+                break
+            r.append((p1, apply_offset(p2)+1)) # X-Y
+        else:
+            i = apply_offset(a)
+            r.append((i, i+1))
+    return r
+
+def apply_ranges(ranges, num):
+    for start,end  in ranges:
+        if end == -1:
+            end = num
+        for i in range(start,end):
+            yield i
+
+
+def read_yaml(p):
+    with open(p) as f:
+        return yaml.safe_load(f)
+
+# read global and job-specific envs from
+def read_env(env):
+    m = env
+    g = ''
+    if isinstance(env, dict):
+        m = env['matrix']
+        if 'globals' in env:
+            g = ' '.join(env['globals']),
+    return g, m
+
+def parse_extra_args(args):
+    try:
+        extra = args.index('--')
+        return args[0:extra], args[extra+1:]
+    except ValueError:
+        return args, []
+
+env_assigment = re.compile(r"[a-zA-Z][a-zA-Z0-9_]*=")
+def gen_env(e):
+    if env_assigment.match(e):
+        return e
+    return '%s=%s' % (e, os.getenv(e, ''))
+
+
+def print_help(cmd):
+    print("""
+Usage: %s [PATH] [RANGE*] [-- [ENV*]]
+
+Parses the travis config in the given path or in the current working directory and runs all specified tests sequentially
+If no range is given, the list of jobs will get printed.
+
+The number of tests can be reduced by specifying one or more ranges:
+* single job: 1 (only first)
+* range: 2-3 (only second and third)
+* open start, only as first range: -4 (jobs 1 to 4)
+* open end, only as last range: 7- (job 7 and all following jobs)
+* open range: - (all jobs)
+
+Complex examples for a matrix wih 12 jobs:
+
+* -4 7 8: runs jobs 1 2 3 4 7 8
+* 1 7-9: runs jobs 1 7 8 9
+* 1 7-9 11-: runs jobs 1 7 8 9 11 12
+* -: runs all jobs
+
+The jobs will be run in clean environments.
+Only DOCKER_PORT, SSH_AUTH_SOCK, and TERM will be kept.
+Additional variable names can be passed at the end.
+
+""" % cmd)
+
+def main(scripts_dir, argv):
+    if '--help' in argv:
+        print_help(argv[0])
+        sys.exit(0)
+
+    args, keep_env = parse_extra_args(argv[1:])
+
+    path, args = find_config_file(args, ['.travis.yml', '.travis.yaml'])
+    global_env, job_envs = read_env(read_yaml(path)['env'])
+
+    if len(args) == 0:
+        jobs = len(job_envs)
+        digits = len(str(jobs))
+        for i in range(jobs):
+            print('Job %s: %s' % ( str(i+1).rjust(digits), job_envs[i]))
+        print("run all with %s -" % sys.argv[0])
+        sys.exit(0)
+
+    ranges = parse_ranges(args, -1)
+
+    run_ci = [os.path.join(scripts_dir, "run_ci"), os.path.dirname(path), global_env]
+
+    extra_env = map(gen_env, keep_env + ['DOCKER_PORT', 'SSH_AUTH_SOCK', 'TERM'])
+    bash = ['env', '-i'] + extra_env + ['bash','-e']
+
+    selection = set(apply_ranges(ranges, len(job_envs)))
+
+    for i in selection:
+        cmd = ' '.join(run_ci + [job_envs[i]])
+        print('\033[1;44mRunning job %d: %s\033[1;m' %(i+1, cmd))
+
+        proc = subprocess.Popen(bash, stdin=subprocess.PIPE)
+        proc.communicate(cmd)
+        if proc.returncode:
+            print('\033[1;41mFailed job %d: %s\033[1;m' %(i+1, cmd))
+            sys.exit(bash.proc)
+
+if __name__ == "__main__":
+    main(os.path.abspath(os.path.dirname(__file__)), sys.argv)

--- a/industrial_ci/scripts/run_travis
+++ b/industrial_ci/scripts/run_travis
@@ -1,4 +1,20 @@
 #!/usr/bin/env python
+
+# Copyright (c) 2017, Mathias Lüdtke
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import print_function
 
 import os


### PR DESCRIPTION
```
Usage: industrial_ci/scripts/run_travis [PATH] [RANGE*] [-- [ENV*]]

Parses the travis config in the given path or in the current working directory and runs all specified tests sequentially
If no range is given, the list of jobs will get printed.

The number of tests can be reduced by specifying one or more ranges:
* single job: 1 (only first)
* range: 2-3 (only second and third)
* open start, only as first range: -4 (jobs 1 to 4)
* open end, only as last range: 7- (job 7 and all following jobs)
* open range: - (all jobs)

Complex examples for a matrix wih 12 jobs:

* -4 7 8: runs jobs 1 2 3 4 7 8
* 1 7-9: runs jobs 1 7 8 9
* 1 7-9 11-: runs jobs 1 7 8 9 11 12
* -: runs all jobs

The jobs will be run in clean environments.
Only DOCKER_PORT, SSH_AUTH_SOCK, and TERM will be kept.
Additional variable names can be passed at the end.
```

It should work for most `industrial_ci` users, but I haven't tested it yet with configs that include escaped variables.
