### PR TITLE
Inject QEMU for cross-platform build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
     - ROS_DISTRO=indigo USE_MOCKUP='industrial_ci/mockups/testpkg_broken_install'  EXPECT_EXIT_CODE=1
     - ROS_DISTRO=indigo USE_MOCKUP='industrial_ci/mockups/testpkg_broken_install'  CATKIN_CONFIG='--no-install -DCMAKE_CXX_FLAGS="-Werror=uninitialized -Werror=return-type"'
     - ROS_DISTRO=indigo DOCKER_IMAGE='mluedtke/ci-test:indigo'
-    - ROS_DISTRO=indigo DOCKER_IMAGE='ros:indigo-ros-core'  ADDITIONAL_DEBS="build-essential python-catkin-tools python-pip"
+    - ROS_DISTRO=indigo DOCKER_IMAGE='arm32v7/ros:indigo-ros-core' ADDITIONAL_DEBS="build-essential python-catkin-tools python-pip" INJECT_QEMU=arm BEFORE_SCRIPT='[[ $(uname -p) == armv7l ]]'
     - ROS_DISTRO=indigo NOT_TEST_BUILD='true'
     - ROS_DISTRO=indigo NOT_TEST_INSTALL='true' BEFORE_SCRIPT='test -z "${CXX+x}"' # test that CXX is not set
     - ROS_DISTRO=indigo NOT_TEST_INSTALL='true' CXX=/usr/bin/gcc BEFORE_SCRIPT='test -z "${CXX+x}"' EXPECT_EXIT_CODE=1 # test the CXX test
@@ -70,6 +70,9 @@ matrix:
     - env: ROS_DISTRO=indigo NOT_TEST_BUILD='true' NOT_TEST_INSTALL='true' POST_PROCESS='I_am_supposed_to_fail'
     - env: ROS_DISTRO=indigo UPSTREAM_WORKSPACE=file USE_DEB=true  # Expected to fail. See https://github.com/ros-industrial/industrial_ci/pull/74
     - env: ROS_DISTRO=jade   UPSTREAM_WORKSPACE=file  ROSINSTALL_FILENAME=.ci.rosinstall
+
+install:
+  - sudo apt-get install qemu-user-static
 script:
   - industrial_ci/_wrap_test.sh # this script is only for internal use
   - if ! [ -z "$POST_PROCESS" ]; then $POST_PROCESS; fi

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -173,6 +173,7 @@ Note that some of these currently tied only to a single option, but we still lea
 * `DOCKER_BUILD_OPTS` (default: not set): Used do specify additional build options for Docker.
 * `DOCKER_RUN_OPTS` (default: not set): Used do specify additional run options for Docker.
 * `EXPECT_EXIT_CODE` (default: 0): exit code must match this value for test to succeed
+* `INJECT_QEMU` (default: not set): Inject static qemu emulator for cross-platform builds, e.g. `INJECT_QEMU=arm`. This requires to install `qemu-user-static` on the host. The emulated build might take much longer!
 * `NOT_TEST_BUILD` (default: not set): If true, tests in `build` space won't be run.
 * `NOT_TEST_INSTALL` (default: not set): If true, tests in `install` space won't be run.
 * `OS_CODE_NAME` (default: derived from ROS_DISTRO): See `this section for the detail <https://github.com/ros-industrial/industrial_ci/blob/master/doc/index.rst#optional-type-of-os-and-distribution>`_.

--- a/industrial_ci/src/docker.sh
+++ b/industrial_ci/src/docker.sh
@@ -36,9 +36,6 @@ function ici_require_run_in_docker() {
   if ! [ "$IN_DOCKER" ]; then
     ici_prepare_docker_image
 
-    docker_uid=$(docker run --rm $DOCKER_IMAGE id -u)
-    docker_gid=$(docker run --rm $DOCKER_IMAGE id -g)
-
     local docker_target_repo_path=/root/src/$TARGET_REPO_NAME
     local docker_ici_src_path=/root/ici
     ici_run_cmd_in_docker -e "TARGET_REPO_PATH=$docker_target_repo_path" \
@@ -93,6 +90,12 @@ function ici_run_cmd_in_docker() {
       "${run_opts[@]}" \
       "$@")
 
+  # detect user inside container
+  local docker_image
+  docker_image=$(docker inspect --format='{{.Config.Image}}' "$cid")
+  docker_uid=$(docker run --rm "${run_opts[@]}" "$docker_image" id -u)
+  docker_gid=$(docker run --rm "${run_opts[@]}" "$docker_image" id -g)
+
   # pass common credentials to container
   for d in .docker .ssh .subversion; do
     if [ -d "$HOME/$d" ]; then
@@ -110,10 +113,10 @@ function ici_run_cmd_in_docker() {
 }
 
 # work-around for https://github.com/moby/moby/issues/34096
-# ensures that the permissions of copied files are owned by the target user
+# ensures that copied files are owned by the target user
 function docker_cp {
   set -o pipefail
-  tar --owner=${docker_uid:-root} --group=${docker_gid:-root} -c -f - -C "$(dirname $1)" "$(basename $1)" | docker cp - $2
+  tar --numeric-owner --owner=${docker_uid:-root} --group=${docker_gid:-root} -c -f - -C "$(dirname $1)" "$(basename $1)" | docker cp - $2
   set +o pipefail
 }
 #######################################


### PR DESCRIPTION
If `DOCKER_IMAGE` or `DOCKER_BASE_IMAGE` point to a different platform, then `INJECT_QEMU` can be set to  the appropriate version that should get injected automatically.

For example for ARM builds, `INJECT_QEMU=arm` has to be set.

Please note:
* For this to work the `qemu-user-static` package needs to be installed on the host (or the CI machine): `sudo apt-get install qemu-user-static`
* There is no need to inject QEMU if it is already present in the selected image
* The build is much slower, it is not suitable for regular CI checks. It might be better to test certain branches only or to provide an image with all dependencies (and QEMU).

includes #236, closes #235 