### PR TITLE
install latest docker in prerelease container

### DIFF
--- a/industrial_ci/src/tests/ros_prerelease.sh
+++ b/industrial_ci/src/tests/ros_prerelease.sh
@@ -38,15 +38,18 @@ function setup_environment() {
     docker build -t "industrial-ci/prerelease" - <<EOF > /dev/null
 FROM ubuntu:xenial
 
-RUN apt-get update -qq && apt-get -qq install --no-install-recommends -y wget ca-certificates sudo
+RUN apt-get update -qq && apt-get -qq install --no-install-recommends -y wget apt-transport-https ca-certificates sudo
 
 RUN echo "deb ${ROS_REPOSITORY_PATH} xenial main" > /etc/apt/sources.list.d/ros-latest.list
 RUN apt-key adv --keyserver "${APTKEY_STORE_SKS}" --recv-key "${HASHKEY_SKS}" \
     || { wget "${APTKEY_STORE_HTTPS}" -O - | sudo apt-key add -; }
 
+RUN echo "deb [arch=\$(dpkg --print-architecture)] https://download.docker.com/linux/ubuntu xenial stable" > /etc/apt/sources.list.d/docker.list
+RUN wget -O - https://download.docker.com/linux/ubuntu/gpg |  apt-key add -
+
 RUN apt-get update -qq \
     && apt-get -qq install --no-install-recommends -y \
-        docker.io \
+        docker-ce \
         git \
         python-ros-buildfarm \
         ros-kinetic-catkin \

--- a/industrial_ci/src/tests/ros_prerelease.sh
+++ b/industrial_ci/src/tests/ros_prerelease.sh
@@ -30,7 +30,7 @@ function setup_environment() {
         user_cmd="useradd ci"
     elif [ -e /var/run/docker.sock ]; then
         DIND_OPTS=-"v /var/run/docker.sock:/var/run/docker.sock"
-        user_cmd="groupadd -g $(stat -c%g /var/run/docker.sock) host_docker && useradd -G host_docker ci"
+        user_cmd="groupadd -o -g $(stat -c%g /var/run/docker.sock) host_docker && useradd -G host_docker ci"
     else
         error "Could not detect docker settings"
     fi


### PR DESCRIPTION
Prerelease tests started to [fail](https://gitlab.com/ipa-mdl/industrial_ci/pipelines/14361205) on Gitlab because of TLS problems.
Updating to a recent docker version [resolves this](https://gitlab.com/ipa-mdl/industrial_ci/pipelines/14361018).

