### PR TITLE
Replace ~ with $HOME for correct expansion.

### DIFF
--- a/industrial_ci/src/docker.sh
+++ b/industrial_ci/src/docker.sh
@@ -86,8 +86,8 @@ function ici_run_cmd_in_docker() {
 
   # pass common credentials to container
   for d in .docker .ssh .subversion; do
-    if [ -d "~/$d" ]; then
-      docker cp "~/$d" "$cid:/root/"
+    if [ -d "$HOME/$d" ]; then
+      docker cp "$HOME/$d" "$cid:/root/"
     fi
   done
 


### PR DESCRIPTION
Some jobs relying on my SSH credentials being copied into the docker container have started to fail. I believe this might be because the `~` character is not correctly expanded inside double quotes [here](https://github.com/ros-industrial/industrial_ci/blob/a0356c3a546d43a1bea819d7ffdb0f61ea849e7c/industrial_ci/src/docker.sh#L89), which were introduced in #240. Replacing with `$HOME` does the job for me.