### PR TITLE
setup ssh key forwarding in gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,15 +3,22 @@
 # https://docs.gitlab.com/ce/ci/docker/using_docker_build.html#using-the-overlayfs-driver
 
 image: docker:git # docker and git clients
+
+# The docker runner does not expose /tmp to the docker-in-docker service
+# This config ensures that the temp folder is located inside the project directory (e.g. for prerelease tests or SSH agent forwarding)
 variables:
-  TMPDIR: "${CI_PROJECT_DIR}.tmp" # needed for prerelease tests with Gitlab's docker-in-docker
+  TMPDIR: "${CI_PROJECT_DIR}.tmp" #
+
+# enable docker-in-docker
 services:
-  - docker:dind # enable docker-in-docker
+  - docker:dind
 
 before_script:
   - apk add --update bash coreutils # install industrial_ci dependencies
   # for regular users: - git clone https://github.com/ros-industrial/industrial_ci .ci_config
   - mkdir .ci_config && cp -a * .ci_config # this is only needed for branch testing of industrial_ci itself
+
+# setup the actual tests
 
 indigo:
   script: .ci_config/gitlab.sh

--- a/gitlab.sh
+++ b/gitlab.sh
@@ -25,4 +25,22 @@ export TARGET_REPO_PATH=$CI_PROJECT_DIR
 export TARGET_REPO_NAME=$CI_PROJECT_NAME
 export _DO_NOT_FOLD=true
 
+if [ -n "$SSH_PRIVATE_KEY" ]; then
+  if [ "$CI_DISPOSABLE_ENVIRONMENT" != true ] && ! [ -f /.dockerenv ] ; then
+    echo "SSH auto set-up cannot be used in non-disposable environments"
+    exit 1
+  fi
+
+  # start SSH agent
+  eval $(ssh-agent -s)
+  # add key to agent
+  ssh-add <(echo "$SSH_PRIVATE_KEY") || { res=$?; echo "could not add ssh key"; exit $res; }
+
+  if [ -n "$SSH_SERVER_HOSTKEYS" ]; then
+    mkdir -p ~/.ssh
+    # setup known hosts
+    echo "$SSH_SERVER_HOSTKEYS" > ~/.ssh/known_hosts
+  fi
+fi
+
 env "$@" bash $DIR_THIS/industrial_ci/src/ci_main.sh


### PR DESCRIPTION
Automates the steps from the [gitlab docs](https://docs.gitlab.com/ee/ci/ssh_keys/README.html#ssh-keys-when-using-the-docker-executor).

`SSH_PRIVATE_KEY` and `SSH_SERVER_HOSTKEYS` have to be added as secret variables beforehand.

Instead of providing `SSH_SERVER_HOSTKEYS`,  StrictHostKeyChecking could be disabled via `.gitlab-ci.yml`, but this is not recommended.

This code ensures that it is only run in docker or in a disposable environemnt (only runners 10.1+).

@130s, @miguelprada: What do you think?