### PR TITLE
set proper uid/gid for files copied to docker

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ services:
   - docker:dind
 
 before_script:
-  - apk add --update bash coreutils # install industrial_ci dependencies
+  - apk add --update bash coreutils tar # install industrial_ci dependencies
   # for regular users: - git clone https://github.com/ros-industrial/industrial_ci .ci_config
   - mkdir .ci_config && cp -a * .ci_config # this is only needed for branch testing of industrial_ci itself
 

--- a/industrial_ci/src/docker.sh
+++ b/industrial_ci/src/docker.sh
@@ -103,6 +103,8 @@ function ici_run_cmd_in_docker() {
   return $ret
 }
 
+# work-around for https://github.com/moby/moby/issues/34096
+# ensures that the permissions of copied files are owned by the target user
 function docker_cp {
   set -o pipefail
   tar --owner=${docker_uid:-root} --group=${docker_gid:-root} -c -f - -C "$(dirname $1)" "$(basename $1)" | docker cp - $2


### PR DESCRIPTION
addresses #247 

Since docker 17.06 ownership of files copied into docker containers is kept instead of beeing rewritten to the target user. This PR emulates the old behavior until this bug was fixed in docker (WIP).

In addition this PR enables passing  credential files even for non-root images.

This patch might break again as soon as the docker bug is fixed.

@ipa-jba: please test