### PR TITLE
A few improvement for potential issues with a custom Docker image

### DIFF
--- a/industrial_ci/src/tests/source_tests.sh
+++ b/industrial_ci/src/tests/source_tests.sh
@@ -83,7 +83,9 @@ ici_time_start setup_rosws
 # Create workspace
 export CATKIN_WORKSPACE=~/catkin_ws
 mkdir -p $CATKIN_WORKSPACE/src
-$ROSWS init $CATKIN_WORKSPACE/src
+if [ ! -f $CATKIN_WORKSPACE/src/.rosinstall ]; then
+  $ROSWS init $CATKIN_WORKSPACE/src
+fi
 case "$UPSTREAM_WORKSPACE" in
 debian)
     echo "Obtain deb binary for upstream packages."

--- a/industrial_ci/src/tests/source_tests.sh
+++ b/industrial_ci/src/tests/source_tests.sh
@@ -141,7 +141,7 @@ fi
 
 ici_time_start rosdep_install
 
-rosdep_opts=(-q --from-paths $CATKIN_WORKSPACE --ignore-src --rosdistro $ROS_DISTRO -y)
+rosdep_opts=(-q --from-paths $CATKIN_WORKSPACE/src --ignore-src --rosdistro $ROS_DISTRO -y)
 if [ -n "$ROSDEP_SKIP_KEYS" ]; then
   rosdep_opts+=(--skip-keys "$ROSDEP_SKIP_KEYS")
 fi


### PR DESCRIPTION
- Not run 'wstool init' when .rosinstall exists.
 In a custom Docker image .rosinstall could exist. In that case `wstool init` returns code 1 and the entire job fails, which with this change can be avoided.
-  'rosdep install' only search src under . Addresses #257.
  `src` folder is assumed in industrial_ci already (e.g. [here](https://github.com/ros-industrial/industrial_ci/blob/749d03f0fc9be6fb2779366ee165184c589362a4/industrial_ci/src/tests/source_tests.sh#L85)) so this change should make sense.