### PR TITLE
[run_travis] Fix encoding error. Add a section in readme .

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -587,6 +587,15 @@ Example:
 
 (ROS_DISTRO could be read from your environment as well)
 
+Run locally using Travis config
+++++++++++++++++++++++++++++++++
+
+Since v0.6.0, you can run locally using `.travis.yml` you already defined for your repository, using [`industrial_ci/scripts/run_travis` script](https://github.com/ros-industrial/industrial_ci/blob/master/industrial_ci/scripts/run_travis). See the help of that script.
+
+::
+
+   rosrun industrial_ci run_travis --help
+
 For maintainers of industrial_ci repository
 ================================================
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -558,7 +558,15 @@ A successful example from `swri-robotics/mapviz <https://github.com/swri-robotic
 Run industrial_ci on local host
 ---------------------------------------
 
+There are a few ways to run CI jobs locally.
+
+Simplest way to run locally
+++++++++++++++++++++++++++++++++
+
 Since version 0.3.3, you can run `industrial_ci` on your local host. This can be useful e.g. when you want to integrate industrial_ci into your CI server.
+
+NOTE that this way the CI config (e.g. `.travis.yml`, `.gitlab-ci.yml`) are not used. So whatever configurations you have in your CI configs need to be added manually.
+
 To do so,
 
 0. `Install Docker <https://docs.docker.com/engine/installation/linux/>`_

--- a/industrial_ci/scripts/run_travis
+++ b/industrial_ci/scripts/run_travis
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 # Copyright (c) 2017, Mathias Lüdtke
 # All rights reserved.


### PR DESCRIPTION
I got an error. 
```
$ ~/industrial_ci/industrial_ci/scripts/run_travis .
  File "/home/n130s/industrial_ci/industrial_ci/scripts/run_travis", line 3
  SyntaxError: Non-ASCII character '\xc3' in file /home/n130s/industrial_ci/industrial_ci/scripts/run_travis on line 3, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
$
```