### PR TITLE
[WIP] rerun_ci script

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -676,7 +676,9 @@ Please note that `run_ci` and `run_travis` will download all dependencies every 
 For recurring runs, e.g. in a debugging session, this might not be desired.
 
 As an alternative `rerun_ci` could be used. It take the same argument as `run_ci`, but will run the build incrementally and only download or compile after changes.
+
 This results in much faster execution for recurring runs, but has some disadvantages as well:
+
 * The user needs to clean-up manually, an instruction to do so is printed at the end of all runs.
 * All parameters incl. the repository path have to be passed explicitly to allow for proper caching.
 * The apt dependencies won't get updated in recurring runs.
@@ -688,8 +690,8 @@ Example:
 
   $ rosrun industrial_ci rerun_ci . ROS_DISTRO=melodic ROS_REPO=ros-shadow-fixed
 
-This will run the tests and commit the result to a Docker image `industrial-ci/rerun_ci/ros_canopen:$HASH`.
-The hash is unique for each argument list, so `rerun_ci . ROS_DISTRO=melodic` and `rerun_ci . ROS_DISTRO=kinetic` do not mix  up.
+This will run the tests and commit the result to a Docker image ``industrial-ci/rerun_ci/ros_canopen:$HASH``.
+The hash is unique for each argument list, so ``rerun_ci . ROS_DISTRO=melodic`` and ``rerun_ci . ROS_DISTRO=kinetic`` do not mix  up.
 However, it will keep consuming disk space with each new combination.
 
 The cached images can be listed with

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -187,9 +187,10 @@ Note that some of these currently tied only to a single option, but we still lea
 * **CCACHE_DIR** (default: not set): If set, `ccache <https://en.wikipedia.org/wiki/Ccache>`_ gets enabled for your build to speed up the subsequent builds in the same job if anything. See `detail. <https://github.com/ros-industrial/industrial_ci/blob/master/doc/index.rst#cache-build-artifacts-to-speed-up-the-subsequent-builds-if-any>`_
 * **DEBUG_BASH** (default: not set): If set with any value (e.g. `true`), all executed commands that are not printed by default to reduce print space will be printed.
 * **DOCKER_BASE_IMAGE** (default: $OS_NAME:$OS_CODE_NAME): Base image used for building the CI image. Could be used to pre-bundle dependecies or to run tests for different architectures. See `this PR <https://github.com/ros-industrial/industrial_ci/pull/174>`_ for more info.
-* **DOCKER_IMAGE** (default: not set): Selects a Docker images different from default one. Please note, this disables the handling of `ROS_REPOSITORY_PATH` and `ROS_DISTRO` as ROS needs already to be installed in the image.
-* **DOCKER_FILE** (default: not set): Instead of pulling an images from the Docker hub, build it from the given path or URL. Please note, this disables the handling of `ROS_REPOSITORY_PATH` and `ROS_DISTRO`, they have to be set in the build file instead.
 * **DOCKER_BUILD_OPTS** (default: not set): Used do specify additional build options for Docker.
+* **DOCKER_FILE** (default: not set): Instead of pulling an images from the Docker hub, build it from the given path or URL. Please note, this disables the handling of `ROS_REPOSITORY_PATH` and `ROS_DISTRO`, they have to be set in the build file instead.
+* **DOCKER_IMAGE** (default: not set): Selects a Docker images different from default one. Please note, this disables the handling of `ROS_REPOSITORY_PATH` and `ROS_DISTRO` as ROS needs already to be installed in the image.
+* **DOCKER_PULL** (default: true): set to false if custom docker image should not be pulled, e.g. if it was created locally
 * **DOCKER_RUN_OPTS** (default: not set): Used to specify additional run options for Docker.
 * **EXPECT_EXIT_CODE** (default: 0): exit code must match this value for test to succeed
 * **INJECT_QEMU** (default: not set): Inject static qemu emulator for cross-platform builds, e.g. `INJECT_QEMU=arm`. This requires to install `qemu-user-static` on the host. The emulated build might take much longer!

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -235,7 +235,7 @@ Some more notes:
 
 * Setting `DOCKER_IMAGE` is a bit tricky:
    * disables the set-up of ROS based on `ROS_REPO` (or non-recommended `ROS_REPOSITORY_PATH`), and ROS_DISTRO.
-   * but `ROS_DISTRO` still needs to be set.  
+   * but `ROS_DISTRO` still needs to be set.
 * Some common credentials such as `.docker`, `.ssh`, `.subversion` are passed from CI native platform to Docker container.
 
 Pass custom variables to Docker
@@ -349,10 +349,10 @@ If pull requests should be checked against the merge parent instead of the stabl
 
 URL can be specified in shortcut form `provider:organization/repository#version`, which is supported for bitbucket, github and gitlab. "`version`" can be either one of the name of the branch, the tagged version, or even a commit. Some (more) concrete examples:
 
-- github:ros-industrial-release/ros_canopen-release#upstream           
+- github:ros-industrial-release/ros_canopen-release#upstream
 - gitlab:ipa-mdl/ci-example#master
 - github:ros-planning/moveit#0.9.9
-  
+
 Alternatively you can use the following forms as URL.:
 
 - https://github.com/ros-industrial/ros_canopen/archive/kinetic.zip
@@ -669,6 +669,28 @@ Since v0.6.0, you can run locally using `.travis.yml` you already defined for yo
 ::
 
    rosrun industrial_ci run_travis --help
+
+Recurring runs for debugging
+++++++++++++++++++++++++++++
+Please note that `run_ci` and `run_travis` will download all dependencies every time, just as CI services would do.
+For recurring runs, e.g. in a debugging session, this might not be desired.
+
+As an alternative `rerun_ci` could be used. It take the same argument as `run_ci`, but will run the build incrementally and only download or compile after changes.
+This results in much faster execution for recurring runs, but has some disadvantages as well:
+* The user needs to clean-up manually, an instruction to do so is printed at the end of all runs.
+* All parameters incl. the repository path have to be passed explicitly to allow for proper caching.
+* The apt dependencies won't get updated in recurring runs.
+* Incremental builds might not work properly for all cases. Especially, it does not help with prerelease tests.
+
+Example:
+
+::
+
+  $ rosrun industrial_ci rerun_ci . ROS_DISTRO=melodic ROS_REPO=ros-shadow-fixed
+
+This will run the tests and commit the result to a Docker image `industrial-ci/rerun_ci/ros_canopen:$HASH`.
+The hash is unique for each argument list, so `rerun_ci . ROS_DISTRO=melodic` and `rerun_ci . ROS_DISTRO=kinetic` do not mix  up.
+However, it will keep consuming disk space with each new combination.
 
 For maintainers of industrial_ci repository
 ================================================

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -692,6 +692,12 @@ This will run the tests and commit the result to a Docker image `industrial-ci/r
 The hash is unique for each argument list, so `rerun_ci . ROS_DISTRO=melodic` and `rerun_ci . ROS_DISTRO=kinetic` do not mix  up.
 However, it will keep consuming disk space with each new combination.
 
+The cached images can be listed with
+::
+
+  $ rosrun industrial_ci rerun_ci --list
+
+
 For maintainers of industrial_ci repository
 ================================================
 

--- a/industrial_ci/CMakeLists.txt
+++ b/industrial_ci/CMakeLists.txt
@@ -3,7 +3,7 @@ project(industrial_ci)
 find_package(catkin REQUIRED)
 catkin_package()
 
-install(PROGRAMS scripts/run_ci
+install(PROGRAMS scripts/run_ci scripts/rerun_ci
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
        )
 catkin_install_python(PROGRAMS scripts/run_travis

--- a/industrial_ci/scripts/rerun_ci
+++ b/industrial_ci/scripts/rerun_ci
@@ -1,0 +1,43 @@
+#!/bin/bash -e
+
+# Copyright (c) 2018, Mathias Lüdtke
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing@, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [ ! -d "$1" ]; then
+  echo "First argument need to be the target directory"
+  exit 1
+fi
+
+repo_dir=$(cd "$1" && pwd)
+shift
+
+_COMMIT_IMAGE_MSG="$repo_dir $*"
+env_hash=($(sha256sum <<< "$_COMMIT_IMAGE_MSG"))
+_COMMIT_IMAGE="industrial-ci/rerun_ci/$(basename "$repo_dir"):${env_hash:0:12}"
+
+force_env=(_COMMIT_IMAGE=$_COMMIT_IMAGE _COMMIT_IMAGE_MSG=$_COMMIT_IMAGE_MSG)
+keep_env=(DOCKER_PORT=$DOCKER_PORT SSH_AUTH_SOCK=$SSH_AUTH_SOCK TERM=$TERM)
+
+if docker image inspect $_COMMIT_IMAGE &> /dev/null; then
+  force_env+=(DOCKER_IMAGE=$_COMMIT_IMAGE  DOCKER_PULL=false)
+fi
+
+env -i "${keep_env[@]}" "$script_dir/run_ci" "$repo_dir" "$@" "${force_env[@]}" || ret=$?
+
+echo "Please do not forget to clean-up: docker rmi $_COMMIT_IMAGE"
+
+exit $ret

--- a/industrial_ci/scripts/rerun_ci
+++ b/industrial_ci/scripts/rerun_ci
@@ -28,7 +28,7 @@ EOF
 
 case "$1" in
 "--list")
-  exec docker image inspect --format '{{index .RepoTags 0}} - {{.Comment}}' $(docker images -q industrial-ci/rerun_ci/*)
+  exec docker image inspect --format '{{index .RepoTags 0}} - {{.Comment}}' $(docker images -q industrial-ci/rerun_ci/*) 2> /dev/null
     ;;
 "--rm")
   remove=true

--- a/industrial_ci/scripts/rerun_ci
+++ b/industrial_ci/scripts/rerun_ci
@@ -17,8 +17,35 @@
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+function show_help {
+  cat - <<'EOF'
+Usage:
+  rerun_ci --list
+  rerun_ci [--clean] TARGET_PATH [PARAM=VALUE>]...
+  rerun_ci --rm TARGET_PATH [PARAM=VALUE>]...
+EOF
+}
+
+case "$1" in
+"--list")
+  exec docker image inspect --format '{{index .RepoTags 0}} - {{.Comment}}' $(docker images -q industrial-ci/rerun_ci/*)
+    ;;
+"--rm")
+  remove=true
+  shift
+    ;;
+"--clean")
+  clean=true
+  shift
+    ;;
+"-h" | "--help" | "")
+  show_help
+  exit 0
+    ;;
+esac
+
 if [ ! -d "$1" ]; then
-  echo "First argument need to be the target directory"
+  show_help
   exit 1
 fi
 
@@ -28,6 +55,13 @@ shift
 _COMMIT_IMAGE_MSG="$repo_dir $*"
 env_hash=($(sha256sum <<< "$_COMMIT_IMAGE_MSG"))
 _COMMIT_IMAGE="industrial-ci/rerun_ci/$(basename "$repo_dir"):${env_hash:0:12}"
+
+if [ "$remove" ]; then
+  exec docker rmi $_COMMIT_IMAGE
+elif [ "$clean" ]; then
+  docker rmi $_COMMIT_IMAGE
+fi
+
 
 force_env=(_COMMIT_IMAGE=$_COMMIT_IMAGE _COMMIT_IMAGE_MSG=$_COMMIT_IMAGE_MSG)
 keep_env=(DOCKER_PORT=$DOCKER_PORT SSH_AUTH_SOCK=$SSH_AUTH_SOCK TERM=$TERM)

--- a/industrial_ci/src/docker.sh
+++ b/industrial_ci/src/docker.sh
@@ -65,6 +65,8 @@ function ici_require_run_in_docker() {
 #######################################
 function ici_run_cmd_in_docker() {
   local run_opts=($DOCKER_RUN_OPTS)
+  local commit_image=$_COMMIT_IMAGE
+  unset _COMMIT_IMAGE
 
   #forward ssh agent into docker container
  local ssh_docker_opts=()
@@ -108,6 +110,9 @@ function ici_run_cmd_in_docker() {
   local ret=0
   wait %% || ret=$?
   trap - INT
+  if [ -n "$commit_image" ]; then
+    docker commit -m "$_COMMIT_IMAGE_MSG" "$cid" $commit_image > /dev/null
+  fi
   docker rm "$cid" > /dev/null
   return $ret
 }

--- a/industrial_ci/src/docker.sh
+++ b/industrial_ci/src/docker.sh
@@ -166,7 +166,7 @@ function ici_prepare_docker_image() {
     fi
   elif [ -z "$DOCKER_IMAGE" ]; then # image was not provided, use default
      ici_build_default_docker_image
-  else
+  elif [ "$DOCKER_PULL" != false ]; then
      docker pull "$DOCKER_IMAGE"
   fi
   ici_time_end # prepare_docker_image

--- a/industrial_ci/src/tests/source_tests.sh
+++ b/industrial_ci/src/tests/source_tests.sh
@@ -122,13 +122,13 @@ if [ -e $CATKIN_WORKSPACE/src/.rosinstall ]; then
     $ROSWS update -t $CATKIN_WORKSPACE/src
 fi
 # TARGET_REPO_PATH is the path of the downstream repository that we are testing. Link it to the catkin workspace
-ln -s $TARGET_REPO_PATH $CATKIN_WORKSPACE/src
+ln -sf $TARGET_REPO_PATH $CATKIN_WORKSPACE/src
 
 if [ "${USE_MOCKUP// }" != "" ]; then
     if [ ! -d "$TARGET_REPO_PATH/$USE_MOCKUP" ]; then
         error "mockup directory '$USE_MOCKUP' does not exist"
     fi
-    ln -s "$TARGET_REPO_PATH/$USE_MOCKUP" $CATKIN_WORKSPACE/src
+    ln -sf "$TARGET_REPO_PATH/$USE_MOCKUP" $CATKIN_WORKSPACE/src
 fi
 
 catkin config --install


### PR DESCRIPTION
`rerun_ci` runs local tests like `run_ci`, but speeds up recurring builds by reusing the  image from the last run.

Each run will commit the container to `industrial-ci/run_ci/$REPO_NAME:$CLI_HASH`. The latter hashes the command line arguments. Thee will added to the images as a comment as well.
So each combination of (absolute) target path and enviromnent settings gets a dedicated image.

There are some differences between `run_ci` and `rerun_ci`:
* the first argument must be the target path, "." is okay as well.
* the images will persist, the users must delete them manually
* the environement gets filled only with the command line arguments

Please give it a try.