### PR TITLE
add upgrade pip to default dockerfile

### DIFF
--- a/industrial_ci/src/docker.sh
+++ b/industrial_ci/src/docker.sh
@@ -234,6 +234,7 @@ RUN sed -i "/^# deb.*multiverse/ s/^# //" /etc/apt/sources.list \
         python-wstool \
         ros-$ROS_DISTRO-catkin \
         ssh-client \
+    && pip install --upgrade pip \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 EOF


### PR DESCRIPTION
This PR fixes the following situation:

I recently added a new rosdep key for a pip python package: https://github.com/ros/rosdistro/pull/17952

This package has first been added to pip on March 4, 2017 (https://pypi.org/project/face_recognition/#history)
`industrial_ci` uses pip with the version 8.1.1 which was released on March 17, 2016 (https://pypi.org/project/pip/#history)
Thus, for pip 8.1.1 the package is not known.

During a CI run, I see the following output
```
You are using pip version 8.1.1, however version 10.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
ERROR: the following rosdeps failed to install
  pip: Failed to detect successful installation of [face_recognition]
```

Would upgrading pip be acceptable?
Still, I don't understand, why `sudo apt-get install python-pip` installs such an old version rather than the latest version in the first place...


