### PR TITLE
Add DOCKER_PULL option

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,3 +33,27 @@ kinetic:
   variables:
     ROS_DISTRO: "kinetic"
     PRERELEASE: "true"
+
+docker_pull_base:
+  script:
+    - docker pull ubuntu:xenial
+    - docker tag ubuntu:xenial industrial-ci/ubuntu:xenial
+    - .industrial_ci/gitlab.sh ROS_DISTRO=kinetic DOCKER_BASE_IMAGE="industrial-ci/ubuntu:xenial" EXPECT_EXIT_CODE=1
+
+docker_no_pull_base:
+  script:
+    - docker pull ubuntu:xenial
+    - docker tag ubuntu:xenial industrial-ci/ubuntu:xenial
+    - .industrial_ci/gitlab.sh ROS_DISTRO=kinetic DOCKER_BASE_IMAGE="industrial-ci/ubuntu:xenial" DOCKER_PULL=false
+
+docker_pull:
+  script:
+    - docker pull rosindustrial/ci:kinetic-xenial-shadow-fixed
+    - docker tag rosindustrial/ci:kinetic-xenial-shadow-fixed industrial-ci/ubuntu:xenial
+    - .industrial_ci/gitlab.sh ROS_DISTRO=kinetic DOCKER_IMAGE="industrial-ci/ubuntu:xenial" EXPECT_EXIT_CODE=1
+
+docker_no_pull:
+  script:
+    - docker pull rosindustrial/ci:kinetic-xenial-shadow-fixed
+    - docker tag rosindustrial/ci:kinetic-xenial-shadow-fixed industrial-ci/ubuntu:xenial
+    - .industrial_ci/gitlab.sh ROS_DISTRO=kinetic DOCKER_IMAGE="industrial-ci/ubuntu:xenial" DOCKER_PULL=false

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -187,9 +187,10 @@ Note that some of these currently tied only to a single option, but we still lea
 * **CCACHE_DIR** (default: not set): If set, `ccache <https://en.wikipedia.org/wiki/Ccache>`_ gets enabled for your build to speed up the subsequent builds in the same job if anything. See `detail. <https://github.com/ros-industrial/industrial_ci/blob/master/doc/index.rst#cache-build-artifacts-to-speed-up-the-subsequent-builds-if-any>`_
 * **DEBUG_BASH** (default: not set): If set with any value (e.g. `true`), all executed commands that are not printed by default to reduce print space will be printed.
 * **DOCKER_BASE_IMAGE** (default: $OS_NAME:$OS_CODE_NAME): Base image used for building the CI image. Could be used to pre-bundle dependecies or to run tests for different architectures. See `this PR <https://github.com/ros-industrial/industrial_ci/pull/174>`_ for more info.
-* **DOCKER_IMAGE** (default: not set): Selects a Docker images different from default one. Please note, this disables the handling of `ROS_REPOSITORY_PATH` and `ROS_DISTRO` as ROS needs already to be installed in the image.
-* **DOCKER_FILE** (default: not set): Instead of pulling an images from the Docker hub, build it from the given path or URL. Please note, this disables the handling of `ROS_REPOSITORY_PATH` and `ROS_DISTRO`, they have to be set in the build file instead.
 * **DOCKER_BUILD_OPTS** (default: not set): Used do specify additional build options for Docker.
+* **DOCKER_FILE** (default: not set): Instead of pulling an images from the Docker hub, build it from the given path or URL. Please note, this disables the handling of `ROS_REPOSITORY_PATH` and `ROS_DISTRO`, they have to be set in the build file instead.
+* **DOCKER_IMAGE** (default: not set): Selects a Docker images different from default one. Please note, this disables the handling of `ROS_REPOSITORY_PATH` and `ROS_DISTRO` as ROS needs already to be installed in the image.
+* **DOCKER_PULL** (default: true): set to false if custom docker image should not be pulled, e.g. if it was created locally
 * **DOCKER_RUN_OPTS** (default: not set): Used to specify additional run options for Docker.
 * **EXPECT_EXIT_CODE** (default: 0): exit code must match this value for test to succeed
 * **INJECT_QEMU** (default: not set): Inject static qemu emulator for cross-platform builds, e.g. `INJECT_QEMU=arm`. This requires to install `qemu-user-static` on the host. The emulated build might take much longer!

--- a/industrial_ci/src/docker.sh
+++ b/industrial_ci/src/docker.sh
@@ -135,6 +135,9 @@ function docker_cp {
 #######################################
 function ici_docker_build() {
   local opts=($DOCKER_BUILD_OPTS)
+  if [ "$DOCKER_PULL" != false ]; then
+    opts+=("--pull")
+  fi
   docker build -t "$DOCKER_IMAGE" "${opts[@]}" "$@"
 }
 
@@ -166,7 +169,7 @@ function ici_prepare_docker_image() {
     fi
   elif [ -z "$DOCKER_IMAGE" ]; then # image was not provided, use default
      ici_build_default_docker_image
-  else
+  elif [ "$DOCKER_PULL" != false ]; then
      docker pull "$DOCKER_IMAGE"
   fi
   ici_time_end # prepare_docker_image


### PR DESCRIPTION
This PR adds a flag to disable automatic pull of images.
Setting it to false assumes that the (base) image was already pulled or provided otherwise.

Cherry-picked from #279 and extended to include `DOCKER_BASE_IMAGE`.
I will update #279 and #280 afterwards.

The test jobs are run on gitlab only: https://gitlab.com/ipa-mdl/industrial_ci/pipelines/23079479