### PR TITLE
remove rosdep install output filter

### DIFF
--- a/industrial_ci/src/tests/source_tests.sh
+++ b/industrial_ci/src/tests/source_tests.sh
@@ -152,9 +152,7 @@ rosdep_opts=(-q --from-paths $CATKIN_WORKSPACE/src --ignore-src --rosdistro $ROS
 if [ -n "$ROSDEP_SKIP_KEYS" ]; then
   rosdep_opts+=(--skip-keys "$ROSDEP_SKIP_KEYS")
 fi
-set -o pipefail # fail if rosdep install fails
-rosdep install "${rosdep_opts[@]}" | { grep "executing command" || true; }
-set +o pipefail
+rosdep install "${rosdep_opts[@]}"
 
 ici_time_end  # rosdep_install
 


### PR DESCRIPTION
Bug in rosdep has been fixed (https://github.com/ros-infrastructure/rosdep/pull/612).
Should get merged after the next release.