### PR TITLE
WIP: Modularize gitlab codes.

### DIFF
--- a/gitlab.sh
+++ b/gitlab.sh
@@ -21,26 +21,11 @@
 # 2016/05/18 http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
 DIR_THIS="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+source industrial_ci/src/tests/gitlab_module.bash
 export TARGET_REPO_PATH=$CI_PROJECT_DIR
 export TARGET_REPO_NAME=$CI_PROJECT_NAME
 export _DO_NOT_FOLD=true
 
-if [ -n "$SSH_PRIVATE_KEY" ]; then
-  if [ "$CI_DISPOSABLE_ENVIRONMENT" != true ] && ! [ -f /.dockerenv ] ; then
-    echo "SSH auto set-up cannot be used in non-disposable environments"
-    exit 1
-  fi
-
-  # start SSH agent
-  eval $(ssh-agent -s)
-  # add key to agent
-  ssh-add <(echo "$SSH_PRIVATE_KEY") || { res=$?; echo "could not add ssh key"; exit $res; }
-
-  if [ -n "$SSH_SERVER_HOSTKEYS" ]; then
-    mkdir -p ~/.ssh
-    # setup known hosts
-    echo "$SSH_SERVER_HOSTKEYS" > ~/.ssh/known_hosts
-  fi
-fi
+pass_sshkey_docker $TARGET_REPO_PATH $TARGET_REPO_NAME
 
 env "$@" bash $DIR_THIS/industrial_ci/src/ci_main.sh

--- a/industrial_ci/src/tests/gitlab_module.sh
+++ b/industrial_ci/src/tests/gitlab_module.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Copyright (c) 2016, Isaac I. Y. Saito
+# Copyright (c) 2017, Mathias Lüdtke
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is the entrypoint for Gitlab CI only.
+
+export _DO_NOT_FOLD=true
+
+#######################################
+# Pass ssh keys to Gitlab CI.
+#
+# Globals:
+#   (None)
+# Arguments:
+#   (None)
+# Returns:
+#   (None)
+#######################################
+function pass_sshkey_docker {
+    # https://docs.gitlab.com/ee/ci/ssh_keys/#ssh-keys-when-using-the-docker-executor
+    if [ -n "$SSH_PRIVATE_KEY" ]; then
+      if [ "$CI_DISPOSABLE_ENVIRONMENT" != true ] && ! [ -f /.dockerenv ] ; then
+        echo "SSH auto set-up cannot be used in non-disposable environments"
+        exit 1
+      fi
+    
+      # start SSH agent
+      eval $(ssh-agent -s)
+      # add key to agent
+      ssh-add <(echo "$SSH_PRIVATE_KEY") || { res=$?; echo "could not add ssh key"; exit $res; }
+    
+      if [ -n "$SSH_SERVER_HOSTKEYS" ]; then
+        mkdir -p ~/.ssh
+        # setup known hosts
+        echo "$SSH_SERVER_HOSTKEYS" > ~/.ssh/known_hosts
+      fi
+    fi
+}


### PR DESCRIPTION
The way Gitlab CI requires on ssh key handling can be the same on every Gitlab repo, so it'd be nice if industrial_ci allows repos to just call that function, instead of running the entire CI process.

For example, I have a CI job that only builds Docker image where build and test steps (in ROS) are not needed. It needs to access other private Gitlab repos. industrial_ci is already pulled in in the same .gitlab-ci.yml for other jobs that use industrial_ci in a "normal" way, so it'd be ideal for the building docker job to be able to use the ssh key function.

There's problem I haven't got this working yet, hence WIP. Gitlab CI (`image: docker:git`) returns error when sourcing the split .sh file (that looked like the one `sh` tried to read `bash`, but I don't have an output now).

```
$ . industrial_ci/src/tests/gitlab_module.bash
sh: 25: industrial_ci/src/tests/gitlab_module.bash: function: not found
sh: 36: industrial_ci/src/tests/gitlab_module.bash: Syntax error: "(" unexpected
```
The following works apparently but bash terminates so can't inherit anything I'm afraid.
```
$ bash industrial_ci/src/tests/gitlab_module.bash
$ 
```
