### PR TITLE
[run_travis] Add '-h' option.

### DIFF
--- a/industrial_ci/scripts/run_travis
+++ b/industrial_ci/scripts/run_travis
@@ -133,7 +133,7 @@ Additional variable names can be passed at the end.
 """ % cmd)
 
 def main(scripts_dir, argv):
-    if '--help' in argv:
+    if ('--help' in argv or '-h' in argv):
         print_help(argv[0])
         sys.exit(0)
 

--- a/industrial_ci/scripts/run_travis
+++ b/industrial_ci/scripts/run_travis
@@ -140,6 +140,11 @@ def main(scripts_dir, argv):
     args, extra_env = parse_extra_args(argv[1:])
 
     path, args = find_config_file(args, ['.travis.yml', '.travis.yaml'])
+    if path is None:
+        print("Could not find Travis config")
+        print_help(argv[0])
+        sys.exit(1)
+
     global_env, job_envs = read_env(read_yaml(path)['env'])
 
     if len(args) == 0:


### PR DESCRIPTION
This fixes https://github.com/ros-industrial/industrial_ci/issues/293 in an adhoc way.

If we want to address #293 in more standard way, we might want to use `argparse` as noted in https://github.com/ros-industrial/industrial_ci/pull/230#pullrequestreview-133449630, but IMO for now this is fine.