### PR TITLE
WIP: [fix] defined but empty 'DOCKER_IMAGE' does not cause error (#296)

### DIFF
--- a/industrial_ci/src/docker.sh
+++ b/industrial_ci/src/docker.sh
@@ -156,7 +156,7 @@ function ici_prepare_docker_image() {
   ici_time_start prepare_docker_image
 
   if [ -n "$DOCKER_FILE" ]; then # docker file was provided
-    DOCKER_IMAGE=${DOCKER_IMAGE:"industrial-ci/custom"}
+    DOCKER_IMAGE=${DOCKER_IMAGE:?"industrial-ci/custom"} || (echo "$DOCKER_IMAGE id defined but empty. Exiting."; exit 1); 
     if [ -f "$TARGET_REPO_PATH/$DOCKER_FILE" ]; then # if single file, run without context
        ici_docker_build - < "$TARGET_REPO_PATH/$DOCKER_FILE" > /dev/null
     elif [ -d "$TARGET_REPO_PATH/$DOCKER_FILE" ]; then # if path, run with context


### PR DESCRIPTION
**Issue**: See #296.

**Approach**: Let CI fail when `DOCKER_IMAGE` is defined but empty. Ref. https://stackoverflow.com/a/16753536/577001

I'm testing on my private repo but not working so far.