### PR TITLE
Error on defined but empty DOCKER_IMAGE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
     - ROS_DISTRO=indigo USE_MOCKUP='industrial_ci/mockups/testpkg_broken_install'  EXPECT_EXIT_CODE=1
     - ROS_DISTRO=indigo USE_MOCKUP='industrial_ci/mockups/testpkg_broken_install'  CATKIN_CONFIG='--no-install -DCMAKE_CXX_FLAGS="-Werror=uninitialized -Werror=return-type"'
     - ROS_DISTRO=indigo DOCKER_IMAGE='mluedtke/ci-test:indigo'
+    - ROS_DISTRO=indigo DOCKER_IMAGE='' EXPECT_EXIT_CODE=1
     - DOCKER_IMAGE='arm32v7/ros:indigo-ros-core' ADDITIONAL_DEBS="build-essential python-catkin-tools python-pip" INJECT_QEMU=arm BEFORE_SCRIPT='[[ $(uname -p) == armv7l ]]'
     - ROS_DISTRO=melodic NOT_TEST_BUILD='true' _GUARD_INTERVAL=10
     - ROS_DISTRO=indigo NOT_TEST_INSTALL='true' BEFORE_SCRIPT='test -z "${CXX+x}"' # test that CXX is not set

--- a/industrial_ci/src/docker.sh
+++ b/industrial_ci/src/docker.sh
@@ -176,9 +176,7 @@ function ici_prepare_docker_image() {
   elif [ -z "${DOCKER_IMAGE+x}" ]; then # image was not provided, use default
      ici_build_default_docker_image
   elif [ -z "$DOCKER_IMAGE" ]; then
-     error "Empty string passed to DOCKER_IMAGE." \
-     "Specify a valid docker image or unset the environment variable to use the default image." 1>&2
-     exit 1
+     error "Empty string passed to DOCKER_IMAGE. Specify a valid docker image or unset the environment variable to use the default image."
   elif [ "$DOCKER_PULL" != false ]; then
      docker pull "$DOCKER_IMAGE"
   fi

--- a/industrial_ci/src/docker.sh
+++ b/industrial_ci/src/docker.sh
@@ -176,7 +176,7 @@ function ici_prepare_docker_image() {
   elif [ -z ${DOCKER_IMAGE+x} ]; then # image was not provided, use default
      ici_build_default_docker_image
   elif [ -z "$DOCKER_IMAGE" ]; then
-     echo "Empty string passed to DOCKER_IMAGE." \
+     error "Empty string passed to DOCKER_IMAGE." \
      "Specify a valid docker image or unset the environment variable to use the default image." 1>&2
      exit 1
   elif [ "$DOCKER_PULL" != false ]; then

--- a/industrial_ci/src/docker.sh
+++ b/industrial_ci/src/docker.sh
@@ -173,7 +173,7 @@ function ici_prepare_docker_image() {
     else # url, run directly
         ici_docker_build "$DOCKER_FILE" > /dev/null
     fi
-  elif [ -z ${DOCKER_IMAGE+x} ]; then # image was not provided, use default
+  elif [ -z "${DOCKER_IMAGE+x}" ]; then # image was not provided, use default
      ici_build_default_docker_image
   elif [ -z "$DOCKER_IMAGE" ]; then
      error "Empty string passed to DOCKER_IMAGE." \

--- a/industrial_ci/src/docker.sh
+++ b/industrial_ci/src/docker.sh
@@ -173,8 +173,12 @@ function ici_prepare_docker_image() {
     else # url, run directly
         ici_docker_build "$DOCKER_FILE" > /dev/null
     fi
-  elif [ -z "$DOCKER_IMAGE" ]; then # image was not provided, use default
+  elif [ -z ${DOCKER_IMAGE+x} ]; then # image was not provided, use default
      ici_build_default_docker_image
+  elif [ -z "$DOCKER_IMAGE" ]; then
+     echo "Empty string passed to DOCKER_IMAGE." \
+     "Specify a valid docker image or unset the environment variable to use the default image." 1>&2
+     exit 1
   elif [ "$DOCKER_PULL" != false ]; then
      docker pull "$DOCKER_IMAGE"
   fi


### PR DESCRIPTION
Check if DOCKER_IMAGE environment variable was set.
If it is set and empty, throw an error.

See https://github.com/ros-industrial/industrial_ci/issues/296
Supersedes #297