### PR TITLE
add os argument to rosdep call

### DIFF
--- a/industrial_ci/src/tests/source_tests.sh
+++ b/industrial_ci/src/tests/source_tests.sh
@@ -148,7 +148,7 @@ fi
 
 ici_time_start rosdep_install
 
-rosdep_opts=(-q --from-paths $CATKIN_WORKSPACE/src --ignore-src --rosdistro $ROS_DISTRO -y)
+rosdep_opts=(-q --from-paths $CATKIN_WORKSPACE/src --ignore-src --rosdistro $ROS_DISTRO --os $OS_NAME:$OS_CODE_NAME -y)
 if [ -n "$ROSDEP_SKIP_KEYS" ]; then
   rosdep_opts+=(--skip-keys "$ROSDEP_SKIP_KEYS")
 fi


### PR DESCRIPTION
The rosdep call was missing the `--os` argument: https://github.com/ros-industrial/industrial_ci/issues/306