### PR TITLE
Remove quiet option from rosdep install

### DIFF
--- a/industrial_ci/src/tests/source_tests.sh
+++ b/industrial_ci/src/tests/source_tests.sh
@@ -148,7 +148,7 @@ fi
 
 ici_time_start rosdep_install
 
-rosdep_opts=(-q --from-paths $CATKIN_WORKSPACE/src --ignore-src --rosdistro $ROS_DISTRO -y)
+rosdep_opts=(--from-paths $CATKIN_WORKSPACE/src --ignore-src --rosdistro $ROS_DISTRO -y)
 if [ -n "$ROSDEP_SKIP_KEYS" ]; then
   rosdep_opts+=(--skip-keys "$ROSDEP_SKIP_KEYS")
 fi


### PR DESCRIPTION
Hi! I would like to open the discussion if removing the quiet option from the rosdep install step could reduce the need for `travis_wait`? 

I noticed that I would have timeouts so one recommendation here is using travis_wait but this in return does not produce output (See https://github.com/travis-ci/travis-ci/issues/7323).

Maybe for some of us would this could be a solution for now.