### PR TITLE
Travis timeout guard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
     - ROS_DISTRO=indigo USE_MOCKUP='industrial_ci/mockups/testpkg_broken_install'  CATKIN_CONFIG='--no-install -DCMAKE_CXX_FLAGS="-Werror=uninitialized -Werror=return-type"'
     - ROS_DISTRO=indigo DOCKER_IMAGE='mluedtke/ci-test:indigo'
     - ROS_DISTRO=indigo DOCKER_IMAGE='arm32v7/ros:indigo-ros-core' ADDITIONAL_DEBS="build-essential python-catkin-tools python-pip" INJECT_QEMU=arm BEFORE_SCRIPT='[[ $(uname -p) == armv7l ]]'
-    - ROS_DISTRO=melodic NOT_TEST_BUILD='true'
+    - ROS_DISTRO=melodic NOT_TEST_BUILD='true' _GUARD_INTERVAL=10
     - ROS_DISTRO=indigo NOT_TEST_INSTALL='true' BEFORE_SCRIPT='test -z "${CXX+x}"' # test that CXX is not set
     - ROS_DISTRO=indigo NOT_TEST_INSTALL='true' CXX=/usr/bin/gcc BEFORE_SCRIPT='test -z "${CXX+x}"' EXPECT_EXIT_CODE=1 # test the CXX test
     - ROS_DISTRO=indigo NOT_TEST_BUILD='true' NOT_TEST_INSTALL='true'  # This may not make much sense. Only for testing purpose.

--- a/travis.sh
+++ b/travis.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Copyright (c) 2016, Isaac I. Y. Saito
-# Copyright (c) 2017, Mathias Lüdtke
+# Copyright (c) 2018, Mathias Lüdtke
 # All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,4 +30,13 @@ if [ "$ABICHECK_MERGE" = "auto" ]; then
   [ "$TRAVIS_PULL_REQUEST" = "false" ] || ABICHECK_MERGE=true
 fi
 
-env "$@" bash $DIR_THIS/industrial_ci/src/ci_main.sh
+function watch_output() {
+  while read -r -t "${_GUARD_INTERVAL:-540}" ||
+        { [[ $? -gt 128 ]] &&
+          echo -en "${ANSI_YELLOW}...industrial_ci is still running...${ANSI_RESET}"; }
+  do
+    echo "$REPLY"
+  done
+}
+
+{ env "$@" stdbuf -oL -eL bash "$DIR_THIS"/industrial_ci/src/ci_main.sh; exit $?; } |& watch_output


### PR DESCRIPTION
This patch will print a line to the output after each 9 minutes of "silence" preventing Travis from stopping the build.
In contrast to `travis_wait` the output will not get printed at the end, but line-wise.

This might introduce a small performance penalty, because each output line is processed by bash,
but I guess this is neglectable.

Not sure if this feature needs an opt-in or opt-out..