### PR TITLE
add blank line after each section

### DIFF
--- a/industrial_ci/src/util.sh
+++ b/industrial_ci/src/util.sh
@@ -86,7 +86,7 @@ function ici_time_end {
         echo -en "ici_fold:end:$ICI_FOLD_NAME"
     fi
     ici_color_output "$color_wrap" "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
-    echo -e "\e[0K\e[${color_wrap}mFunction $ICI_FOLD_NAME returned with code '${exit_code}' after $(( $elapsed_seconds / 60 )) min $(( $elapsed_seconds % 60 )) sec \e[0m"
+    echo -e "\e[0K\e[${color_wrap}mFunction $ICI_FOLD_NAME returned with code '${exit_code}' after $(( $elapsed_seconds / 60 )) min $(( $elapsed_seconds % 60 )) sec \e[0m\n"
 
     unset ICI_FOLD_NAME
     if [ "$DEBUG_BASH" ] && [ "$DEBUG_BASH" == true ]; then set -x; fi


### PR DESCRIPTION
This should help to separate the sections visually.

Before: https://travis-ci.org/ros-industrial/industrial_ci/jobs/449857546
After: https://travis-ci.org/ipa-mdl/industrial_ci/jobs/450475634
