### PR TITLE
Revert "remove rosdep install output filter"

### DIFF
--- a/industrial_ci/src/tests/source_tests.sh
+++ b/industrial_ci/src/tests/source_tests.sh
@@ -152,7 +152,9 @@ rosdep_opts=(-q --from-paths $CATKIN_WORKSPACE/src --ignore-src --rosdistro $ROS
 if [ -n "$ROSDEP_SKIP_KEYS" ]; then
   rosdep_opts+=(--skip-keys "$ROSDEP_SKIP_KEYS")
 fi
-rosdep install "${rosdep_opts[@]}"
+set -o pipefail # fail if rosdep install fails
+rosdep install "${rosdep_opts[@]}" | { grep "executing command" || true; }
+set +o pipefail
 
 ici_time_end  # rosdep_install
 


### PR DESCRIPTION
Reverts ros-industrial/industrial_ci#287
The main ROS repository still ships with rosdep 0.12.2.