### PR TITLE
run_travis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ notifications:
 env:
   global:
     - POST_PROCESS='echo "post processing reached"'
-    - BEFORE_SCRIPT='echo current dir: $(pwd)'
+    - "BEFORE_SCRIPT='echo current dir: $(pwd)'"
 
   matrix:
     - ROS_DISTRO=hydro  USE_MOCKUP='industrial_ci/mockups/industrial_ci_testpkg' VERBOSE_OUTPUT='true'

--- a/industrial_ci/scripts/run_travis
+++ b/industrial_ci/scripts/run_travis
@@ -98,7 +98,7 @@ def parse_extra_args(args):
     except ValueError:
         return args, []
 
-env_assigment = re.compile(r"[a-zA-Z][a-zA-Z0-9_]*=")
+env_assigment = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*=")
 def gen_env(e):
     if env_assigment.match(e):
         return e


### PR DESCRIPTION
Small fixes for run_travis. Now `run_travis` can parse `industral_ci`'s .travis.yml again.