### PR TITLE
 include EOL distros in rosdep update

### DIFF
--- a/industrial_ci/src/util.sh
+++ b/industrial_ci/src/util.sh
@@ -172,12 +172,16 @@ function ici_enforce_deprecated {
 
 function ici_retry {
   local tries=$1; shift
+  local ret=0
 
   for ((i=1;i<=tries;i++)); do
     "$@" && return 0
+    ret=$?
     sleep 1;
   done
-  error "'$*' failed $tries times"
+
+  ici_color_output ${ANSI_RED} "'$*' failed $tries times"
+  return $ret
 }
 
 if ! which sudo > /dev/null; then

--- a/industrial_ci/src/util.sh
+++ b/industrial_ci/src/util.sh
@@ -170,6 +170,16 @@ function ici_enforce_deprecated {
     fi
 }
 
+function ici_retry {
+  local tries=$1; shift
+
+  for ((i=1;i<=tries;i++)); do
+    "$@" && return 0
+    sleep 1;
+  done
+  error "'$*' failed $tries times"
+}
+
 if ! which sudo > /dev/null; then
   function sudo {
     "$@"


### PR DESCRIPTION
Addresses https://github.com/ros-infrastructure/rosdep/pull/647
The flag will only be set for EOL distros on systems which support this flag.