### PR TITLE
Run cleanup for apt resource when DOCKER_COMMIT is on.

### DIFF
--- a/industrial_ci/src/ci_main.sh
+++ b/industrial_ci/src/ci_main.sh
@@ -49,6 +49,10 @@ fi
 if [ "${AFTER_SCRIPT// }" != "" ]; then
   ici_time_start after_script
 
+  if [ -z "$DOCKER_COMMIT" ]; then
+      apt-get clean && rm -rf /var/lib/apt/lists/*
+  fi
+
   bash -e -c "cd $TARGET_REPO_PATH; ${AFTER_SCRIPT}"
 
   ici_time_end  # after_script


### PR DESCRIPTION
## Problem aimed to be addressed
Using a Docker image where cleaning apt resource (? I don't know appropriate term for this) was not done, hash mismatch error can occur (as e.g. [this on askubuntu.com](https://askubuntu.com/questions/41605/trouble-downloading-packages-list-due-to-a-hash-sum-mismatch-error)).

## Changes this PR add
Run apt resource cleanup, only when DOCKER_COMMIT is set, which enables `docker commit` image and allows the users to reuse the image built during the run of industrial_ci.
