### PR TITLE
use host network for travis

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -25,6 +25,9 @@ export TARGET_REPO_PATH=$TRAVIS_BUILD_DIR
 export TARGET_REPO_NAME=${TRAVIS_REPO_SLUG##*/}
 export PYTHONUNBUFFERED=${PYTHONUNBUFFERED:1}
 
+export DOCKER_BUILD_OPTS="--network=host $DOCKER_BUILD_OPTS"
+export DOCKER_RUN_OPTS="--network=host $DOCKER_RUN_OPTS"
+
 if [ "$ABICHECK_MERGE" = "auto" ]; then
   export ABICHECK_MERGE=false
   [ "$TRAVIS_PULL_REQUEST" = "false" ] || ABICHECK_MERGE=true


### PR DESCRIPTION
possible fix for #364 

For Travis (=fresh VM per build job) this should be safe.
For Gitlab this might not be a good default.
