### PR TITLE
run prerelease tests for melodic instead of indigo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ env:
     - ROS_DISTRO=indigo NOT_TEST_BUILD='true' NOT_TEST_INSTALL='true' POST_PROCESS='I_am_supposed_to_fail'
     - ROS_DISTRO=indigo CATKIN_PARALLEL_JOBS='-p1' ROS_PARALLEL_JOBS='-j1'  # Intend build on low-power platform
     # - env: ROS_DISTRO=indigo PRERELEASE=true  ## Comment out because this is meaningless for always failing without prerelease testable contents in industrial_ci.
-    - ROS_DISTRO=indigo PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=1 DOCKER_BASE_IMAGE=something
-    - ROS_DISTRO=indigo PRERELEASE=true USE_MOCKUP='industrial_ci/mockups/failing_test' EXPECT_EXIT_CODE=1
+    - ROS_DISTRO=melodic PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=1 DOCKER_BASE_IMAGE=something
+    - ROS_DISTRO=melodic PRERELEASE=true USE_MOCKUP='industrial_ci/mockups/failing_test' EXPECT_EXIT_CODE=1
     - ROS_DISTRO=kinetic PRERELEASE=true PRERELEASE_REPONAME=industrial_ci
     - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=debian AFTER_SCRIPT='ccache 2> /dev/null && exit 1; [ "$?" = "127" ]'
      # Using default file name for ROSINSTALL_FILENAME, test CCACHE, verify cache was filled


### PR DESCRIPTION
indigo is not supported anymore (https://github.com/ros-infrastructure/ros_buildfarm_config/pull/137)