### PR TITLE
switch to default Travis notification settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,6 @@ services:
   - docker
 # Force travis to use its minimal image with default Python settings
 language: generic
-notifications:
-  #  Whoever receives success and/or failure via email
-  email:
-    recipients:
-      - gm130s@gmail.com  # Change this to yours should you copy this file.
 
 git:
   quiet: true


### PR DESCRIPTION
https://docs.travis-ci.com/user/notifications/#default-notification-settings:

> By default, email notifications are sent to the committer and the commit author when they are members of the repository, that is they have
> - push or admin permissions for public repositories.
> - pull, push or admin permissions for private repositories.