### PR TITLE
use Ubuntu mirror for Travis

### DIFF
--- a/industrial_ci/src/docker.sh
+++ b/industrial_ci/src/docker.sh
@@ -236,6 +236,7 @@ FROM $DOCKER_BASE_IMAGE
 ENV ROS_DISTRO $ROS_DISTRO
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+RUN if [ -n '$_UBUNTU_MIRROR' ]; then sed -i -e 's%http://archive.ubuntu.com/ubuntu%$_UBUNTU_MIRROR%' /etc/apt/sources.list; fi
 
 RUN apt-get update -qq \
     && apt-get -qq install --no-install-recommends -y apt-utils gnupg wget ca-certificates lsb-release dirmngr

--- a/travis.sh
+++ b/travis.sh
@@ -24,6 +24,7 @@ DIR_THIS="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export TARGET_REPO_PATH=$TRAVIS_BUILD_DIR
 export TARGET_REPO_NAME=${TRAVIS_REPO_SLUG##*/}
 export PYTHONUNBUFFERED=${PYTHONUNBUFFERED:1}
+export _UBUNTU_MIRROR=${_UBUNTU_MIRROR-http://us-east-1.ec2.archive.ubuntu.com/ubuntu/}
 
 if [ "$ABICHECK_MERGE" = "auto" ]; then
   export ABICHECK_MERGE=false


### PR DESCRIPTION
This is a hotfix for #406  to use the EC2 mirror on Travis.
@gavanderhoorn: please test

The hard-coded mirror is set on some (but not all) Travis machines as well.
For other/custom CI systems, this mirror might not work properly, so it gets only set for Travis.
The introduced variable `_UBUNTU_MIRROR` is not public and therefore not supported apart from internal use.

A fix for `master` is a little more complex and will follow later.