### PR TITLE
Add set -a flag to export all vars/functions

### DIFF
--- a/industrial_ci/src/ci_main.sh
+++ b/industrial_ci/src/ci_main.sh
@@ -21,6 +21,7 @@
 ## See ./README.rst for the detailed usage.
 
 set -e # exit script on errors
+set -a # export each variable / function (enables usage in after_script)
 if [ "$DEBUG_BASH" ]; then set -x; fi # print trace if DEBUG
 
 # Define some env vars that need to come earlier than util.sh


### PR DESCRIPTION
I noticed that if I want to use e.g. ici_exec_in_workspace in an after script I have to 
```
source "${ICI_SRC_PATH}/workspace.sh
```
but I figured that it would be nice to have all the functions within the after script.

Open for discussion.