### PR TITLE
pass PATH in run_travis

### DIFF
--- a/industrial_ci/scripts/run_travis
+++ b/industrial_ci/scripts/run_travis
@@ -156,7 +156,7 @@ def main(scripts_dir, argv):
 
     run_ci = [os.path.join(scripts_dir, "run_ci"), os.path.dirname(path), global_env]
 
-    bash = ['env', '-i'] +map(gen_env, ['DOCKER_PORT', 'SSH_AUTH_SOCK', 'TERM']) + ['bash','-e']
+    bash = ['env', '-i'] +map(gen_env, ['DOCKER_PORT', 'PATH', 'SSH_AUTH_SOCK', 'TERM']) + ['bash','-e']
 
     selection = set(apply_ranges(ranges, len(job_envs)))
 


### PR DESCRIPTION
fixes #409, should get backported to `legacy`.

@agutenkunst: please test