### PR TITLE
support for ROS2 Eloquent Elusor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ env:
     - ROS_DISTRO=crystal _EXTERNAL_REPO='github:ros-controls/control_msgs#crystal-devel'
     - ROS_DISTRO=crystal _EXTERNAL_REPO='github:ros-controls/control_msgs#crystal-devel' PRERELEASE=true
     - ROS_DISTRO=dashing _EXTERNAL_REPO='github:ros-controls/control_msgs#crystal-devel'
+    - ROS_DISTRO=eloquent _EXTERNAL_REPO='github:ros-controls/control_msgs#crystal-devel'
 
     # Format tests
     - ROS_DISTRO=indigo TARGET_WORKSPACE='industrial_ci/mockups/format_tests/cpp/LLVM' CLANG_FORMAT_CHECK='LLVM' CLANG_FORMAT_VERSION=3.8

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -34,6 +34,7 @@ Following `ROS distributions <http://wiki.ros.org/Distributions>`__ / `ROS2 <htt
 * `Bouncy <https://index.ros.org/doc/ros2/Releases/Bouncy/>`__ *(EOL)*
 * `Crystal <https://index.ros.org/doc/ros2/Releases/Release-Crystal-Clemmys/>`__
 * `Dashing <https://index.ros.org/doc/ros2/Releases/Release-Dashing-Diademata/>`__
+* `Eloquent <https://index.ros.org/doc/ros2/Releases/Release-Eloquent-Elusor/>`__
 
 Supported CIs
 +++++++++++++

--- a/industrial_ci/src/env.sh
+++ b/industrial_ci/src/env.sh
@@ -118,6 +118,10 @@ function set_ros_variables {
     "crystal"|"dashing")
         ros2_defaults "bionic"
         ;;
+    "eloquent")
+        ros2_defaults "bionic"
+        DEFAULT_DOCKER_IMAGE=
+        ;;
     esac
 
     local prefix=ros


### PR DESCRIPTION
[First sync is out](https://discourse.ros.org/t/ros-2-eloquent-elusor-call-for-testing-and-package-releases/10923).
Docker images are not available yet.