### PR TITLE
reorder allowed failures in run_travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,10 @@ matrix:
   allow_failures:
     - env: ROS_DISTRO=indigo NOT_TEST_BUILD='true' NOT_TEST_INSTALL='true' POST_PROCESS='I_am_supposed_to_fail'
   include:
+    - script:
+      - industrial_ci/scripts/run_travis
+      - industrial_ci/scripts/run_travis 1
+      env: [run_travis]
     - script: shellcheck -x *.sh industrial_ci/scripts/*_ci industrial_ci/src/*.sh industrial_ci/src/*/*.sh industrial_ci/*.sh
       env: [shellcheck]
 

--- a/industrial_ci/scripts/run_travis
+++ b/industrial_ci/scripts/run_travis
@@ -91,6 +91,19 @@ def read_env(env):
             g = ' '.join(env['global'])
     return g, m
 
+def read_allow_failures(config):
+    try:
+        af =  config['matrix']['allow_failures']
+    except:
+        return list()
+    return list(x['env'] for x in af)
+
+def read_num_include(config):
+    try:
+        return len(config['matrix']['include'])
+    except:
+        return 0
+
 def parse_extra_args(args):
     try:
         extra = args.index('--')
@@ -140,7 +153,12 @@ def main(scripts_dir, argv):
     args, extra_env = parse_extra_args(argv[1:])
 
     path, args = find_config_file(args, ['.travis.yml', '.travis.yaml'])
-    global_env, job_envs = read_env(read_yaml(path)['env'])
+    config = read_yaml(path)
+    global_env, job_envs = read_env(config['env'])
+    allow_failures = read_allow_failures(config)
+    job_envs =   [ x for x in job_envs if x not in allow_failures ] \
+               + [None] * read_num_include(config) \
+               + [ x for x in job_envs if x in allow_failures ]
 
     if len(args) == 0:
         if(len(global_env) > 0):
@@ -148,7 +166,9 @@ def main(scripts_dir, argv):
         jobs = len(job_envs)
         digits = len(str(jobs))
         for i in range(jobs):
-            print('Job %s: %s' % ( str(i+1).rjust(digits), job_envs[i]))
+            print('Job %s%s: %s' % ( str(i+1).rjust(digits),
+                                     ' (allow_failures)' if job_envs[i] in allow_failures else '',
+                                     job_envs[i] if job_envs[i] is not None else "<unsupported job from 'include' section>"))
         print("run all with %s -" % sys.argv[0])
         sys.exit(0)
 
@@ -161,14 +181,18 @@ def main(scripts_dir, argv):
     selection = set(apply_ranges(ranges, len(job_envs)))
 
     for i in selection:
+        if job_envs[i] is None:
+            print("\033[1;43mSkipped job %d, because jobs from 'include' section are not supported\033[1;m" %(i+1,))
+            continue
         cmd = ' '.join(run_ci + [job_envs[i]] + map(gen_env, extra_env))
-        print('\033[1;44mRunning job %d: %s\033[1;m' %(i+1, cmd))
+        print('\033[1;44mRunning job %d%s: %s\033[1;m' %(i+1, ' (allow_failures)' if job_envs[i] in allow_failures else '', cmd))
 
         proc = subprocess.Popen(bash, stdin=subprocess.PIPE)
         proc.communicate(cmd)
         if proc.returncode:
             print('\033[1;41mFailed job %d: %s\033[1;m' %(i+1, cmd))
-            sys.exit(proc.returncode)
+            if job_envs[i] not in allow_failures:
+                sys.exit(proc.returncode)
 
 if __name__ == "__main__":
     main(os.path.abspath(os.path.dirname(__file__)), sys.argv)


### PR DESCRIPTION
Moves `allow_failures` jobs to the end of the list, just as Travis does.

For industrial_ci:
```
Globals: POST_PROCESS='echo "post processing reached"' AFTER_SETUP_TARGET_WORKSPACE='echo current dir: $(pwd)'
Job  1: ROS_DISTRO=indigo TARGET_WORKSPACE='industrial_ci/mockups/industrial_ci_testpkg' VERBOSE_OUTPUT='true' CATKIN_LINT=true
Job  2: ROS_DISTRO=indigo TARGET_WORKSPACE='industrial_ci/mockups/industrial_ci_testpkg' CMAKE_ARGS="-DFAIL_CMAKE=true" EXPECT_EXIT_CODE=1
Job  3: ROS_DISTRO=indigo TARGET_WORKSPACE='industrial_ci/mockups/industrial_ci_testpkg' CATKIN_LINT=pedantic EXPECT_EXIT_CODE=1
Job  4: ROS_DISTRO=indigo TARGET_WORKSPACE='industrial_ci/mockups/industrial_ci_testpkg' ROSDEP_SKIP_KEYS="rospy_tutorials rostest" EXPECT_EXIT_CODE=1
Job  5: ROS_DISTRO=indigo TARGET_WORKSPACE='industrial_ci/mockups/testpkg_broken_install'  EXPECT_EXIT_CODE=1
Job  6: DOCKER_IMAGE='arm32v7/ros:indigo-ros-core' ADDITIONAL_DEBS="build-essential python-catkin-tools python-pip" INJECT_QEMU=arm BEFORE_INIT='[[ $(uname -p) == armv7l ]]'
Job  7: ROS_DISTRO=melodic NOT_TEST_BUILD='true' _GUARD_INTERVAL=10
Job  8: ROS_DISTRO=indigo NOT_TEST_INSTALL='true' BEFORE_INIT='test -z "${CXX+x}"'
Job  9: ROS_DISTRO=indigo NOT_TEST_INSTALL='true' CXX=/usr/bin/gcc BEFORE_INIT='test -z "${CXX+x}"' EXPECT_EXIT_CODE=1
Job 10: ROS_DISTRO=indigo NOT_TEST_BUILD='true' NOT_TEST_INSTALL='true'
Job 11: ROS_DISTRO=indigo CATKIN_PARALLEL_JOBS='-p1' ROS_PARALLEL_JOBS='-j1'
Job 12: ROS_DISTRO=melodic PRERELEASE=true PRERELEASE_DOWNSTREAM_DEPTH=1
Job 13: ROS_DISTRO=melodic PRERELEASE=true TARGET_WORKSPACE='industrial_ci/mockups/failing_test' PRERELEASE_REPONAME="failing_test" EXPECT_EXIT_CODE=1
Job 14: ROS_DISTRO=kinetic PRERELEASE=true PRERELEASE_REPONAME=industrial_ci
Job 15: ROS_DISTRO=indigo UPSTREAM_WORKSPACE=debian AFTER_SCRIPT='ccache 2> /dev/null && exit 1; [ "$?" = "127" ]'
Job 16: ROS_DISTRO=indigo UPSTREAM_WORKSPACE=file CCACHE_DIR=$HOME/.ccache AFTER_SCRIPT='num=($(ccache -s | grep "files in cache")) && (( num[-1] > 0 ))'
Job 17: ROS_DISTRO=indigo UPSTREAM_WORKSPACE=file USE_DEB=true EXPECT_EXIT_CODE=1
Job 18: ROS_DISTRO=indigo UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-industrial/industrial_ci/master/.travis.rosinstall
Job 19: ROS_DISTRO=indigo USE_DEB=true
Job 20: ROS_DISTRO=indigo USE_DEB=false
Job 21: ROS_DISTRO=indigo ADDITIONAL_DEBS="ros-indigo-opencv3" VERBOSE_OUTPUT='false'
Job 22: ROS_DISTRO=indigo ADDITIONAL_DEBS="ros-hydro-opencv3" DEBUG_BASH='true' EXPECT_EXIT_CODE=100
Job 23: ROS_DISTRO=kinetic   UPSTREAM_WORKSPACE=file  ROSINSTALL_FILENAME=.ci.rosinstall
Job 24: ROS_DISTRO=kinetic   UPSTREAM_WORKSPACE=file ROSINSTALL_FILENAME=.i.do.not.exist EXPECT_EXIT_CODE=1
Job 25: {'DOCKER_BASE_IMAGE="ros:kinetic-ros-base" ROS_REPO=ros NOT_TEST_BUILD=\'true\' DEBUG_BASH=\'true\' VERBOSE_OUTPUT=\'false\' DOCKER_COMMIT="img_temp" POST_PROCESS=\'eval docker image inspect $DOCKER_COMMIT --format="$DOCKER_COMMIT': '\\"{{.Size}}\\" bytes"\''}
Job 26: ROS_DISTRO=lunar ROS_REPO=ros-shadow-fixed TARGET_WORKSPACE='industrial_ci/mockups/industrial_ci_testpkg'
Job 27: ROS_DISTRO=melodic AFTER_SCRIPT='grep -q ID=ubuntu /etc/os-release && grep -q VERSION_CODENAME=bionic /etc/os-release'
Job 28: ROS_DISTRO=melodic BEFORE_INIT='grep -q ID=debian /etc/os-release && grep -q VERSION_ID=\"9\" /etc/os-release' EXPECT_EXIT_CODE=1
Job 29: ROS_DISTRO=melodic OS_NAME=debian OS_CODE_NAME=stretch AFTER_SCRIPT='grep -q ID=debian /etc/os-release && grep -q VERSION_ID=\"9\" /etc/os-release'
Job 30: ROS_DISTRO=melodic OS_NAME=debian EXPECT_EXIT_CODE=1
Job 31: ROS_DISTRO=melodic OS_NAME=debian OS_CODE_NAME=bionic EXPECT_EXIT_CODE=1
Job 32: ROS_DISTRO=kinetic _EXTERNAL_REPO='github:ros-industrial/industrial_core@kinetic-devel'
Job 33: ROS_DISTRO=kinetic _EXTERNAL_REPO='gh:ros-industrial/motoman_experimental#kinetic-devel' UPSTREAM_WORKSPACE='.travis.rosinstall -ros-industrial/industrial_experimental/IRC_v2'
Job 34: ROS_DISTRO=kinetic _EXTERNAL_REPO='github:ros-controls/ros_control#kinetic-devel' UPSTREAM_WORKSPACE=file ROSINSTALL_FILENAME=ros_control.rosinstall ROS_PARALLEL_TEST_JOBS=-j1
Job 35: ROS_DISTRO=kinetic _EXTERNAL_REPO='github:ipa320/cob_calibration_data#indigo_dev' ROS_REPO=ros UPSTREAM_WORKSPACE=file AFTER_SCRIPT='rosenv ./.travis.xacro_test.sh'
Job 36: ROS_DISTRO=indigo _EXTERNAL_REPO='github:ros/actionlib#38ce66e2ae2ec9c19cf12ab22d57a8134a9285be' ROS_REPO=ros ABICHECK_URL=url ABICHECK_MERGE=true
Job 37: ROS_DISTRO=kinetic _EXTERNAL_REPO='github:ros-industrial/ros_canopen#0.7.5' ROS_REPO=ros ABICHECK_URL='github:ros-industrial/ros_canopen#0.7.1' ABICHECK_MERGE=false EXPECT_EXIT_CODE=1
Job 38: ROS_DISTRO=kinetic _EXTERNAL_REPO='github:ros-industrial/ros_canopen#0.7.6' ABICHECK_URL='github:ros-industrial/ros_canopen#0.7.5' ABICHECK_MERGE=false
Job 39: ROS_DISTRO=kinetic _EXTERNAL_REPO='github:ros-controls/ros_control#kinetic-devel' UPSTREAM_WORKSPACE="ros_control.rosinstall -ros_control -ros_controllers"
Job 40: ROS_DISTRO=melodic NOT_TEST_DOWNSTREAM=true BUILDER=colcon _EXTERNAL_REPO='github:ros-controls/ros_control#melodic-devel' UPSTREAM_WORKSPACE="github:ros-controls/control_msgs#kinetic-devel github:ros-controls/realtime_tools#melodic-devel github:ros-controls/control_toolbox#melodic-devel" DOWNSTREAM_WORKSPACE="github:ros-controls/ros_controllers#melodic-devel"
Job 41: ROS_DISTRO=bouncy _EXTERNAL_REPO='github:ros2/joystick_drivers#bouncy'
Job 42: ROS_DISTRO=crystal _EXTERNAL_REPO='github:ros-controls/control_msgs#crystal-devel'
Job 43: ROS_DISTRO=crystal _EXTERNAL_REPO='github:ros-controls/control_msgs#crystal-devel' PRERELEASE=true
Job 44: ROS_DISTRO=dashing _EXTERNAL_REPO='github:ros-controls/control_msgs#crystal-devel'
Job 45: ROS_DISTRO=indigo TARGET_WORKSPACE='industrial_ci/mockups/format_tests/cpp/LLVM' CLANG_FORMAT_CHECK='LLVM' CLANG_FORMAT_VERSION=3.8
Job 46: ROS_DISTRO=kinetic TARGET_WORKSPACE='industrial_ci/mockups/format_tests/cpp/LLVM' CLANG_FORMAT_CHECK='LLVM'
Job 47: ROS_DISTRO=kinetic TARGET_WORKSPACE='industrial_ci/mockups/format_tests/cpp/WebKit' CLANG_FORMAT_CHECK='LLVM' EXPECT_EXIT_CODE=1
Job 48: ROS_DISTRO=kinetic TARGET_WORKSPACE='industrial_ci/mockups/format_tests/cpp/WebKit' CLANG_FORMAT_CHECK='file'
Job 49: ROS_DISTRO=kinetic TARGET_WORKSPACE='industrial_ci/mockups/format_tests/cpp/LLVM' CLANG_FORMAT_CHECK='WebKit' EXPECT_EXIT_CODE=1
Job 50: <skipped include>
Job 51 (allow_failures): ROS_DISTRO=indigo NOT_TEST_BUILD='true' NOT_TEST_INSTALL='true' POST_PROCESS='I_am_supposed_to_fail'
```