### PR TITLE
readme: repository was migrated to travis.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 ================
 Industrial CI
 ================
-.. image:: https://travis-ci.org/ros-industrial/industrial_ci.svg?branch=legacy
-    :target: https://travis-ci.org/ros-industrial/industrial_ci
+.. image:: https://travis-ci.com/ros-industrial/industrial_ci.svg?branch=legacy
+    :target: https://travis-ci.com/ros-industrial/industrial_ci
     :alt: Travis CI status
 .. image:: https://gitlab.com/ipa-mdl/industrial_ci/badges/legacy/pipeline.svg
     :target: https://gitlab.com/ipa-mdl/industrial_ci/commits/legacy


### PR DESCRIPTION
As per subject.

Not sure whether you'd rather have this in `master`, or whether you can 'port' this to that branch yourself.
