### PR TITLE
fix ROS2 ardent

### DIFF
--- a/industrial_ci/src/builders/colcon.sh
+++ b/industrial_ci/src/builders/colcon.sh
@@ -19,7 +19,7 @@ _colcon_event_handlers=(desktop_notification- status- terminal_title-)
 
 function builder_setup {
     ici_install_pkgs_for_command colcon python3-colcon-common-extensions
-    if [ "$ROS_DISTRO" = "kinetic" ]; then
+    if [ "$ROS_DISTRO" = "kinetic" ] || [ "$ROS_DISTRO" = "ardent" ]; then
         ici_install_pkgs_for_command pip3 python3-pip
         ici_asroot pip3 install -U setuptools
     fi


### PR DESCRIPTION
`ardent` needs the same fix as `kinetic`, since both are based on `xenial`.