### PR TITLE
add --recursive for vcs import

### DIFF
--- a/industrial_ci/src/workspace.sh
+++ b/industrial_ci/src/workspace.sh
@@ -79,6 +79,10 @@ function ici_setup_git_client {
   fi
 }
 
+function ici_vcs_import {
+    vcs import --recursive "$@"
+}
+
 function ici_import_repository {
     local sourcespace=$1; shift
     local url=$1; shift
@@ -94,7 +98,7 @@ function ici_import_repository {
         *)
             ;;
     esac
-    vcs import --recursive "$sourcespace" <<< "{repositories: {'${parts[0]}': {type: '${parts[1]}', url: '${parts[2]}', version: '${parts[3]}'}}}"
+    ici_vcs_import "$sourcespace" <<< "{repositories: {'${parts[0]}': {type: '${parts[1]}', url: '${parts[2]}', version: '${parts[3]}'}}}"
 }
 
 function ici_import_file {
@@ -109,7 +113,7 @@ function ici_import_file {
     *)
         ici_install_pkgs_for_command vcs "${PYTHON_VERSION_NAME}-vcstool"
         ici_setup_git_client
-        vcs import --recursive "$sourcespace" < "$file"
+        ici_vcs_import "$sourcespace" < "$file"
     ;;
     esac
 
@@ -130,7 +134,7 @@ function ici_import_url {
     *)
         ici_install_pkgs_for_command vcs "${PYTHON_VERSION_NAME}-vcstool"
         ici_setup_git_client
-        processor=(vcs import --recursive "$sourcespace")
+        processor=(ici_vcs_import "$sourcespace")
     ;;
     esac
 

--- a/industrial_ci/src/workspace.sh
+++ b/industrial_ci/src/workspace.sh
@@ -94,7 +94,7 @@ function ici_import_repository {
         *)
             ;;
     esac
-    vcs import "$sourcespace" <<< "{repositories: {'${parts[0]}': {type: '${parts[1]}', url: '${parts[2]}', version: '${parts[3]}'}}}"
+    vcs import --recursive "$sourcespace" <<< "{repositories: {'${parts[0]}': {type: '${parts[1]}', url: '${parts[2]}', version: '${parts[3]}'}}}"
 }
 
 function ici_import_file {
@@ -109,7 +109,7 @@ function ici_import_file {
     *)
         ici_install_pkgs_for_command vcs "${PYTHON_VERSION_NAME}-vcstool"
         ici_setup_git_client
-        vcs import "$sourcespace" < "$file"
+        vcs import --recursive "$sourcespace" < "$file"
     ;;
     esac
 
@@ -130,7 +130,7 @@ function ici_import_url {
     *)
         ici_install_pkgs_for_command vcs "${PYTHON_VERSION_NAME}-vcstool"
         ici_setup_git_client
-        processor=(vcs import "$sourcespace")
+        processor=(vcs import --recursive "$sourcespace")
     ;;
     esac
 


### PR DESCRIPTION
apparently `vcs import` has `--recursive` disabed by default
which is why github submodules are not pulled during setup_ws

from `vcs import --help`:
>  --recursive        Recurse into submodules (default: False)

I hope I covered all occurrences correctly...
