### PR TITLE
WIP: merging moveit_ci

### DIFF
--- a/industrial_ci/mockups/failing_test/test/no_talker.test
+++ b/industrial_ci/mockups/failing_test/test/no_talker.test
@@ -1,11 +1,11 @@
 <launch>
   <!-- This launch file is used to test the rostest on CI server works. It can be any ROS tests that are generic enough -->
 
-  <param name="hztest1/topic" value="chatter" />
-  <param name="hztest1/hz" value="10.0" />
-  <param name="hztest1/hzerror" value="0.5" />
-  <param name="hztest1/test_duration" value="1.0" />
-  <param name="hztest1/wait_time" value="1.0" />
-  <test test-name="hztest_test" pkg="rostest" type="hztest"
-        name="hztest1" />
+  <test test-name="hztest_test" pkg="rostest" type="hztest" name="hztest1">
+    <param name="topic" value="chatter" />
+    <param name="hz" value="10.0" />
+    <param name="hzerror" value="0.5" />
+    <param name="test_duration" value="5.0" />
+    <param name="wait_time" value="5.0" />
+  </test>
 </launch>

--- a/industrial_ci/mockups/industrial_ci_testpkg/test/example_ros.test
+++ b/industrial_ci/mockups/industrial_ci_testpkg/test/example_ros.test
@@ -3,11 +3,11 @@
 
   <node name="talker" pkg="rospy_tutorials" type="talker.py" />
 
-  <param name="hztest1/topic" value="chatter" />  
-  <param name="hztest1/hz" value="10.0" />
-  <param name="hztest1/hzerror" value="0.5" />
-  <param name="hztest1/test_duration" value="5.0" />    
-  <param name="hztest1/wait_time" value="21.0" />    
-  <test test-name="hztest_test" pkg="rostest" type="hztest"
-        name="hztest1" />
+  <test test-name="hztest_test" pkg="rostest" type="hztest" name="hztest1">
+    <param name="topic" value="chatter" />
+    <param name="hz" value="10.0" />
+    <param name="hzerror" value="0.5" />
+    <param name="test_duration" value="5.0" />
+    <param name="wait_time" value="5.0" />
+  </test>
 </launch>

--- a/industrial_ci/src/folding/none.sh
+++ b/industrial_ci/src/folding/none.sh
@@ -17,8 +17,10 @@
 
 function  ici_start_fold() {
     shift 3
+    ici_color_output $ANSI_BLUE ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 }
 
 function  ici_end_fold() {
     shift 4
+    ici_color_output "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
 }

--- a/industrial_ci/src/tests/source_tests.sh
+++ b/industrial_ci/src/tests/source_tests.sh
@@ -38,8 +38,8 @@ function run_clang_tidy {
         return 0
     fi
 
-    local build; build="$(dirname "$db")"
-    local name; name="$(basename "$build")"
+    local build="$(dirname "$db")"
+    local name="$(basename "$build")"
 
     local max_jobs="${CLANG_TIDY_JOBS:-$(nproc)}"
     if ! [ "$max_jobs" -ge 1 ]; then

--- a/industrial_ci/src/util.sh
+++ b/industrial_ci/src/util.sh
@@ -117,9 +117,7 @@ function ici_time_start {
     echo # blank line
 
     ici_start_fold "$ICI_TIME_ID" "$ICI_FOLD_NAME" "$ICI_START_TIME"
-
-    ici_color_output $ANSI_BLUE ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
-    ici_color_output $ANSI_BLUE "Starting function '$ICI_FOLD_NAME'"
+    ici_color_output $ANSI_BLUE "$ICI_FOLD_NAME"
     if [ "$DEBUG_BASH" ] && [ "$DEBUG_BASH" == true ]; then set -x; fi
 }
 
@@ -148,10 +146,9 @@ function ici_time_end {
     local end_time; end_time=$(date -u +%s%N)
     local elapsed_seconds; elapsed_seconds=$(( (end_time - ICI_START_TIME)/1000000000 ))
 
+    echo -en "\e[${color_wrap}m"  # just set color, no output
     ici_end_fold "$ICI_TIME_ID" "$name" "$ICI_START_TIME" "$end_time"
-
-    ici_color_output "$color_wrap" "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
-    ici_color_output "$color_wrap" "Function '$name' returned with code '${exit_code}' after $(( elapsed_seconds / 60 )) min $(( elapsed_seconds % 60 )) sec"
+    ici_color_output "$color_wrap" "'$name' returned with code '${exit_code}' after $(( elapsed_seconds / 60 )) min $(( elapsed_seconds % 60 )) sec"
 
     ICI_FOLD_NAME=
     if [ "$DEBUG_BASH" ] && [ "$DEBUG_BASH" == true ]; then set -x; fi


### PR DESCRIPTION
As a follow up of our discussion in https://github.com/ros-planning/moveit_ci/pull/100, I looked a little deeper into the differences between `industrial_ci` and `moveit_ci`. I like your code base very much! It's a lot cleaner and more modular than ours, supporting several CI providers, ROS versions, and builders. On the other hand, `moveit_ci` has some features that are missing in `industrial_ci`. Thus, I would like to see these two projects to merge. From my point of view, features of `moveit_ci` that are interesting to port are:
- **Hierarchically nested folding**
  Travis supports nested folding and we make heavy use of it to nicely structure the web output,
  see [here](https://travis-ci.org/ros-visualization/rviz/jobs/624369126) for an example.
  Recently, Travis also added support for nested timing, which we didn't yet implement.
- **Unbound variable checking**
  You already use bash options `errexit` and `pipefail`. I'm wondering, why you don't use `nounset` as well? Checking for unbound variables can easily detect spelling errors in variables ([see best practices](https://bertvv.github.io/cheat-sheets/Bash.html#writing-robust-scripts-and-debugging)). We hardened `moveit_ci` a while ago along this line and found a few issues doing so...
My suggestion is to "declare" all variables with their defaults in a separate `variables.sh` file to avoid introducing default syntax `${var:-}` everywhere (which would be error-prone again). 
- **Consider CI provider's global timeout**
  Usually CI providers have a global timeout for the job, the default for public Travis jobs is 50min.
  If a build takes longer (which frequently occurs for MoveIt, when built from scratch), Travis doesn't save the cache (most notably ccache), such that the next build attempt will not be any faster.
To avoid this issue, we implemented (https://github.com/ros-planning/moveit_ci/commit/b66a50a7ea7ec489888c47edb92c7aea1ee8ec2a) an internal timeout mechanism that deliberately exits the main CI script, leaving Travis enough time to save the cache.
I'm not sure Travis changed the default behavior and saves the cache meanwhile... If not, this is an essential feature for large projects like MoveIt.
- **Fail on cmake/compiler warnings**
  We have a mechanism to check for any warnings during the build process: [`check_warnings.sh`](https://github.com/ros-planning/moveit_ci/blob/b711c028f866997c8a0f17feec63f7232955cf2f/check_warnings.sh).
A poor man's solution would simply set `-Werror`, but this would make the compiler fail on the first warning. Our solution compiles the whole project and subsequently checks for `stderr` output.
- **Support for codecov.io**
  This was only recently added (https://github.com/ros-planning/moveit_ci/pull/96) and just compiles everything with option `--coverage` with [subsequent calls to lcov](https://github.com/ros-planning/moveit_ci/blob/b711c028f866997c8a0f17feec63f7232955cf2f/travis.sh#L398-L411).
For better results, the build should use debug options as well, but this caused issues with ccache on Travis (https://github.com/ros-planning/moveit_ci/pull/96#issuecomment-558390669).
- **Speed optimizations**
  I have seen some optimization potential with regard to build time:
  - In `moveit_ci`, we restrict slow tests, like `clang-tidy`, to [files that actually changed in a PR](https://github.com/ros-planning/moveit_ci/blob/master/check_clang_tidy.sh#L20-L32).
  - The base for an ABI check usually doesn't change across many tests and thus is a good candidate for caching. Marking the corresponding folder for caching in `.travis.yml` and checking for it's existence might be sufficient.
  - I particularly liked the `DOCKER_COMMIT` feature. Is it possible to commit the image to [dockerhub](https://hub.docker.com/) as well? How do you handle login credentials in this case?
- **Verbosity**
  Personally, I don't like the generated output of `industrial_ci`. Marking sections via `>>>>>` and `<<<<<` clutters the output and _imho_ is superfluous if you have folding. In moveit_ci we use boldface to mark those main section headers. The first commit in this PR ports moveit_ci's folding approach [generating a much cleaner output](https://travis-ci.com/rhaschke/rviz/builds/141174778).
Additionally, I have the following remarks:
  - In contrast to the documentation, `VERBOSE_OUTPUT` seems to be true by default (see [here](https://travis-ci.com/rhaschke/rviz/builds/141174778)).
  - You suppress the output of many commands via `ici_quiet`. While this is a great function, I would reduce its use to a minimum. Using hierarchical folding will allow to better structure the output and avoid clutter while keeping those outputs.
  - Because most commands are not echoed, it's hard to follow the bash script from the web output.
    In moveit_ci we have [various `travis_run_*` functions](https://github.com/ros-planning/moveit_ci/blob/b711c028f866997c8a0f17feec63f7232955cf2f/util.sh#L224-L250) that essentially all [echo the passed command](https://github.com/ros-planning/moveit_ci/blob/b711c028f866997c8a0f17feec63f7232955cf2f/util.sh#L183) and most bash commands go through this wrapper...
  - When a particular command fails and thus exits the main CI script, I suggest to `not` close open folds. This allows us to immediately browse to the erroneous output, which wouldn't be hidden in a - potentially deeply nested - fold otherwise.

This PR just comprises a few tests that I initially did as well as a few minor cleanups/fixes.
Consider them as a starting point for further discussions. I'm looking forward to contribute to this package and bring together the best from two worlds...