### PR TITLE
Support for CI on top of ros2 nightly images

### DIFF
--- a/industrial_ci/src/env.sh
+++ b/industrial_ci/src/env.sh
@@ -123,6 +123,10 @@ function set_ros_variables {
     "eloquent")
         ros2_defaults "bionic"
         ;;
+    "foxy")
+        ros2_defaults "bionic"
+        DOCKER_IMAGE=${DOCKER_IMAGE:-osrf/ros2:nightly}
+        ;;
     esac
 
     local prefix=ros

--- a/industrial_ci/src/workspace.sh
+++ b/industrial_ci/src/workspace.sh
@@ -234,15 +234,12 @@ function ici_exec_in_workspace {
 function ici_install_dependencies {
     local extend=$1; shift
     local skip_keys=$1; shift
-    local cmake_prefix_path
-    cmake_prefix_path="$(ici_exec_in_workspace "$extend" . env | grep -oP '^CMAKE_PREFIX_PATH=\K.*')" || true
-
     rosdep_opts=(-q --from-paths "$@" --ignore-src -y)
     if [ -n "$skip_keys" ]; then
       rosdep_opts+=(--skip-keys "$skip_keys")
     fi
     set -o pipefail # fail if rosdep install fails
-    ROS_PACKAGE_PATH=$cmake_prefix_path ici_exec_in_workspace "$extend" "." rosdep install "${rosdep_opts[@]}" | { grep "executing command" || true; }
+    ici_exec_in_workspace "$extend" "." rosdep install "${rosdep_opts[@]}" | { grep "executing command" || true; }
     set +o pipefail
 }
 


### PR DESCRIPTION
Hi all, I created a way simpler and stupider version of ici for ROS 2 a while back ([ros2ci](https://github.com/mikaelarguedas/ros2ci/)). Main purpose was to be able to run CI on both released ROS 2 distros and ROS 2 nightly builds to catch breakage of packages against upcoming versions of ROS 2.

Now that ICI supports colcon + ROS 2 (hat tip @ipa-mdl :+1::tada:), I'd like to integrate the support for nightly builds instead of maintaining something on the side.

I'm opening this to start discussion of supporting nightly ROS 2 CI in ICI.
Feature description:
- run jobs based on OSRF's nightly ros2 docker images (Linux only)
- build a "middle-lay" with missing dependencies
- build and test packages on top of it

Is it a use case ICI would be interested in supporting?

---

Content of this PR:
- https://github.com/ros-industrial/industrial_ci/commit/bb03f8451811bd6cf5ab866c34dd2e3b07c89f54: Modify ICI to forward declare the ROS 2 distros as soon as they are [announced / used in the nightly builds](https://github.com/ros2/ros2/pull/829), with a blanket empty "DEFAULT_DOCKER_IMAGE"
- https://github.com/ros-industrial/industrial_ci/commit/c61ecab8324047b177b5d818d4f9fdcbd4fe0981 Extend instead of overriding ROS_PACKAGE_PATH to keep the one set in the upstream image (This should not be needed or merged IMO as thiscan modify behavior for all users and there are likely good reasons to override. This is a hack to work around a current rosdep/ROS2 issue https://github.com/osrf/docker_images/pull/328)

Users wanting to run CI based on nightly builds could modify their travis config as follows:
```diff
 env:
   matrix:
     - ROS_DISTRO="dashing" ROS_REPO=main
     - ROS_DISTRO="eloquent" ROS_REPO=main
+    - DOCKER_IMAGE="osrf/ros2:nightly" UPSTREAM_WORKSPACE="additional_repos.repos"
```

- `osrf/ros2:nightly` being the docker image provided daily by osrf with the content of the latest nightly build
- `additional_repos.repos` the list of upstream packages needed to compile the repository that are NOT part of the nightly image

Example of [repo using this](https://github.com/Karsten1987/confbot_robot/blob/ca85f937cf51b597477837c4a636dad88fc39a20/.travis.yml) and [travis job](https://travis-ci.org/Karsten1987/confbot_robot/jobs/627319651?utm_medium=notification&utm_source=github_status)
