### PR TITLE
Revert "work-around for chained colcon workspaces"

### DIFF
--- a/industrial_ci/src/workspace.sh
+++ b/industrial_ci/src/workspace.sh
@@ -234,15 +234,12 @@ function ici_exec_in_workspace {
 function ici_install_dependencies {
     local extend=$1; shift
     local skip_keys=$1; shift
-    local cmake_prefix_path
-    cmake_prefix_path="$(ici_exec_in_workspace "$extend" . env | grep -oP '^CMAKE_PREFIX_PATH=\K.*')" || true
-
     rosdep_opts=(-q --from-paths "$@" --ignore-src -y)
     if [ -n "$skip_keys" ]; then
       rosdep_opts+=(--skip-keys "$skip_keys")
     fi
     set -o pipefail # fail if rosdep install fails
-    ROS_PACKAGE_PATH=$cmake_prefix_path ici_exec_in_workspace "$extend" "." rosdep install "${rosdep_opts[@]}" | { grep "executing command" || true; }
+    ici_exec_in_workspace "$extend" "." rosdep install "${rosdep_opts[@]}" | { grep "executing command" || true; }
     set +o pipefail
 }
 


### PR DESCRIPTION
This reverts commit 09618f49562b1bbdc98b1385d9ef7a560b81ec85.

as discussed in https://github.com/ros-industrial/industrial_ci/pull/454#discussion_r360407669, this work-around is not needed anymore.