### PR TITLE
Readme: Add legacy version note

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,8 @@ Quick Start
 
 With a few steps, you can start in your client repository using CI confiurations stored in `industrial_ci`.
 
+* Note: This is the **legacy version**. For the new version, see the ``master`` branch.
+
 For Travis CI
 --------------
 


### PR DESCRIPTION
Hi again. I assume that the legacy is default so that existing projects that clone without `--branch` won't break. However, for fools like me it's not obvious that I might be better off cloning master, because all the documentation for the new (master) version is only on the master branch. So I thought it might be useful to mention early in the readme that you're reading about the legacy version.

I just recently tried setting up a repo using industrial ci, and it took me some time to realize that I was on an old version. I think something like this would have made me realize right away.