### PR TITLE
work-around for chained colcon workspaces with cmake-only packages

### DIFF
--- a/industrial_ci/src/workspace.sh
+++ b/industrial_ci/src/workspace.sh
@@ -257,12 +257,19 @@ function ici_exec_in_workspace {
 function ici_install_dependencies {
     local extend=$1; shift
     local skip_keys=$1; shift
+
+    local cmake_prefix_path
+    if [ "$ROS_VERSION" -eq 2 ]; then
+      # work-around for https://github.com/ros-infrastructure/rosdep/issues/724
+      cmake_prefix_path="$(ici_exec_in_workspace "$extend" . env | grep -oP '^CMAKE_PREFIX_PATH=\K.*'):" || true
+    fi
+
     rosdep_opts=(-q --from-paths "$@" --ignore-src -y)
     if [ -n "$skip_keys" ]; then
       rosdep_opts+=(--skip-keys "$skip_keys")
     fi
     set -o pipefail # fail if rosdep install fails
-    ici_exec_in_workspace "$extend" "." rosdep install "${rosdep_opts[@]}" | { grep "executing command" || true; }
+    ROS_PACKAGE_PATH="$cmake_prefix_path$ROS_PACKAGE_PATH" ici_exec_in_workspace "$extend" "." rosdep install "${rosdep_opts[@]}" | { grep "executing command" || true; }
     set +o pipefail
 }
 


### PR DESCRIPTION
This reverts commit 5a3936f0fe60ba42485d1cba8a51e231f8294b78.
Fixes #475 

ToDo:

- [ ] add test case
- [x] cherry-pick changes from https://github.com/ros-industrial/industrial_ci/pull/454