### PR TITLE
Edit doc to extend travis support to bitbucket beta

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,8 +51,8 @@ For Travis CI
 --------------
 
 1. Activate CI for your github repository on `Travis CI <https://travis-ci.com/>`__).
-    1. You may do so either at https://travis-ci.com/github/YOUR_GITHUB_ORGANIZATION or at https://travis-ci.com/github/YOUR_GITHUB_USER (depending on where your repository sits).
-    2. Activate CI beta for your bitbucket repository is similar, but the target link that your status badge directs to needs to be modified from https://travis-ci.com/USERNAME/REPO_NAME to https://travis-ci.com/bitbucket/USERNAME/REPO_NAME. By default, the generated link directs to a github repository.
+    a. You may do so either at https://travis-ci.com/github/YOUR_GITHUB_ORGANIZATION or at https://travis-ci.com/github/YOUR_GITHUB_USER (depending on where your repository sits).
+    b. Activate CI beta for your bitbucket repository is similar, but the target link that your status badge directs to needs to be modified from https://travis-ci.com/USERNAME/REPO_NAME to https://travis-ci.com/bitbucket/USERNAME/REPO_NAME. By default, the generated link directs to a github repository.
 2. Add `.travis.yml` file to your repository root (`complete template <https://github.com/ros-industrial/industrial_ci/blob/master/doc/.travis.yml>`__):
 
 ::
@@ -77,7 +77,7 @@ For Gitlab CI
 
 1. Enable CI for your repo. Please refer to `official doc <https://docs.gitlab.com/ee/ci/quick_start/>`__ for the steps to do so. Note for Gitlab CI, necessary steps might be different between hosted version (i.e. the one on gitlab.com) v.s. the one on your own server, which Gitlab doesn't always clarify in its documentation.
     1. For your server version, enable a runner for your Gitlab project which uses the Docker executor. See instructions on how to `install <https://docs.gitlab.com/runner/install/index.html>`__ and `register <https://docs.gitlab.com/runner/register/index.html>`__ such a runner with your Gitlab instance if you haven't done so yet.
-1. In `.gitlab-ci.yml` file in your client repo, add the following minimal configuration (this snippet can be the entire content of the file), replacing indigo for your chosen distro:
+2. In `.gitlab-ci.yml` file in your client repo, add the following minimal configuration (this snippet can be the entire content of the file), replacing indigo for your chosen distro:
 
 ::
 

--- a/README.rst
+++ b/README.rst
@@ -50,8 +50,9 @@ With a few steps, you can start in your client repository using CI confiurations
 For Travis CI
 --------------
 
-1. Activate CI for your github repository on `Travis CI <https://travis-ci.com/>`__). You may do so either at https://travis-ci.com/github/YOUR_GITHUB_ORGANIZATION or at https://travis-ci.com/github/YOUR_GITHUB_USER (depending on where your repository sits).
-  1. Activate CI beta for your bitbucket repository is similar, but the target link that your status badge directs to needs to be modified from https://travis-ci.com/USERNAME/REPO_NAME to https://travis-ci.com/bitbucket/USERNAME/REPO_NAME. By default, the generated link directs to a github repository.
+1. Activate CI for your github repository on `Travis CI <https://travis-ci.com/>`__).
+    1. You may do so either at https://travis-ci.com/github/YOUR_GITHUB_ORGANIZATION or at https://travis-ci.com/github/YOUR_GITHUB_USER (depending on where your repository sits).
+    2. Activate CI beta for your bitbucket repository is similar, but the target link that your status badge directs to needs to be modified from https://travis-ci.com/USERNAME/REPO_NAME to https://travis-ci.com/bitbucket/USERNAME/REPO_NAME. By default, the generated link directs to a github repository.
 2. Add `.travis.yml` file to your repository root (`complete template <https://github.com/ros-industrial/industrial_ci/blob/master/doc/.travis.yml>`__):
 
 ::
@@ -75,7 +76,7 @@ For Gitlab CI
 -------------
 
 1. Enable CI for your repo. Please refer to `official doc <https://docs.gitlab.com/ee/ci/quick_start/>`__ for the steps to do so. Note for Gitlab CI, necessary steps might be different between hosted version (i.e. the one on gitlab.com) v.s. the one on your own server, which Gitlab doesn't always clarify in its documentation.
-  1. For your server version, enable a runner for your Gitlab project which uses the Docker executor. See instructions on how to `install <https://docs.gitlab.com/runner/install/index.html>`__ and `register <https://docs.gitlab.com/runner/register/index.html>`__ such a runner with your Gitlab instance if you haven't done so yet.
+    1. For your server version, enable a runner for your Gitlab project which uses the Docker executor. See instructions on how to `install <https://docs.gitlab.com/runner/install/index.html>`__ and `register <https://docs.gitlab.com/runner/register/index.html>`__ such a runner with your Gitlab instance if you haven't done so yet.
 1. In `.gitlab-ci.yml` file in your client repo, add the following minimal configuration (this snippet can be the entire content of the file), replacing indigo for your chosen distro:
 
 ::

--- a/README.rst
+++ b/README.rst
@@ -51,8 +51,10 @@ For Travis CI
 --------------
 
 1. Activate CI for your github repository on `Travis CI <https://travis-ci.com/>`__).
-    a. You may do so either at https://travis-ci.com/github/YOUR_GITHUB_ORGANIZATION or at https://travis-ci.com/github/YOUR_GITHUB_USER (depending on where your repository sits).
-    b. Activate CI beta for your bitbucket repository is similar, but the target link that your status badge directs to needs to be modified from https://travis-ci.com/USERNAME/REPO_NAME to https://travis-ci.com/bitbucket/USERNAME/REPO_NAME. By default, the generated link directs to a github repository.
+
+   a) You may do so either at https://travis-ci.com/github/YOUR_GITHUB_ORGANIZATION or at https://travis-ci.com/github/YOUR_GITHUB_USER (depending on where your repository sits).
+   b) Activate CI beta for your bitbucket repository is similar, but the target link that your status badge directs to needs to be modified from https://travis-ci.com/USERNAME/REPO_NAME to https://travis-ci.com/bitbucket/USERNAME/REPO_NAME. By default, the generated link directs to a github repository.
+
 2. Add `.travis.yml` file to your repository root (`complete template <https://github.com/ros-industrial/industrial_ci/blob/master/doc/.travis.yml>`__):
 
 ::
@@ -76,7 +78,9 @@ For Gitlab CI
 -------------
 
 1. Enable CI for your repo. Please refer to `official doc <https://docs.gitlab.com/ee/ci/quick_start/>`__ for the steps to do so. Note for Gitlab CI, necessary steps might be different between hosted version (i.e. the one on gitlab.com) v.s. the one on your own server, which Gitlab doesn't always clarify in its documentation.
-    1. For your server version, enable a runner for your Gitlab project which uses the Docker executor. See instructions on how to `install <https://docs.gitlab.com/runner/install/index.html>`__ and `register <https://docs.gitlab.com/runner/register/index.html>`__ such a runner with your Gitlab instance if you haven't done so yet.
+
+   1. For your server version, enable a runner for your Gitlab project which uses the Docker executor. See instructions on how to `install <https://docs.gitlab.com/runner/install/index.html>`__ and `register <https://docs.gitlab.com/runner/register/index.html>`__ such a runner with your Gitlab instance if you haven't done so yet.
+
 2. In `.gitlab-ci.yml` file in your client repo, add the following minimal configuration (this snippet can be the entire content of the file), replacing indigo for your chosen distro:
 
 ::

--- a/README.rst
+++ b/README.rst
@@ -50,8 +50,8 @@ With a few steps, you can start in your client repository using CI confiurations
 For Travis CI
 --------------
 
-1. Activate CI for your github repository on `Travis CI <https://travis-ci.org/>`__). You may do so either at https://travis-ci.org/profile/YOUR_GITHUB_ORGANIZATION or at https://travis-ci.org/profile/YOUR_GITHUB_USER (depending on where your repository sits).
-
+1. Activate CI for your github repository on `Travis CI <https://travis-ci.com/>`__). You may do so either at https://travis-ci.com/github/YOUR_GITHUB_ORGANIZATION or at https://travis-ci.com/github/YOUR_GITHUB_USER (depending on where your repository sits).
+  1. Activate CI beta for your bitbucket repository is similar, but the target link that your status badge directs to needs to be modified from https://travis-ci.com/USERNAME/REPO_NAME to https://travis-ci.com/bitbucket/USERNAME/REPO_NAME. By default, the generated link directs to a github repository.
 2. Add `.travis.yml` file to your repository root (`complete template <https://github.com/ros-industrial/industrial_ci/blob/master/doc/.travis.yml>`__):
 
 ::


### PR DESCRIPTION
Addressing #497 

- Change https://travis-ci.org to https://travis-ci.com for the bitbucket beta support;
- Address status badges' target link problem in the documentation. 