### PR TITLE
vcstool is always python3

### DIFF
--- a/industrial_ci/src/workspace.sh
+++ b/industrial_ci/src/workspace.sh
@@ -87,7 +87,7 @@ function ici_import_repository {
     local sourcespace=$1; shift
     local url=$1; shift
 
-    ici_install_pkgs_for_command vcs "${PYTHON_VERSION_NAME}-vcstool"
+    ici_install_pkgs_for_command vcs python3-vcstool
 
     IFS=" " read -r -a parts <<< "$(ici_resolve_scheme "$url")" # name, type, url, version
 
@@ -111,7 +111,7 @@ function ici_import_file {
         bsdtar -C "$sourcespace" -xf "$file"
         ;;
     *)
-        ici_install_pkgs_for_command vcs "${PYTHON_VERSION_NAME}-vcstool"
+        ici_install_pkgs_for_command vcs python3-vcstool
         ici_setup_git_client
         ici_vcs_import "$sourcespace" < "$file"
     ;;
@@ -132,7 +132,7 @@ function ici_import_url {
         processor=(bsdtar -C "$sourcespace" -xf-)
         ;;
     *)
-        ici_install_pkgs_for_command vcs "${PYTHON_VERSION_NAME}-vcstool"
+        ici_install_pkgs_for_command vcs python3-vcstool
         ici_setup_git_client
         processor=(ici_vcs_import "$sourcespace")
     ;;


### PR DESCRIPTION
There is no working way to install `python-vcstool`. It is always `python3-vcstool`. This change affects only pre-noetic distros