### PR TITLE
source handling

### DIFF
--- a/industrial_ci/src/util.sh
+++ b/industrial_ci/src/util.sh
@@ -79,7 +79,11 @@ function ici_hook() {
 
   local script=${!name}
   if [ -n "$script" ]; then
-    ici_run "$1" _sub_shell "$script"
+    if [ "${script%% *}" == "source" ]; then
+      ici_run "$1" eval "$script"
+    else
+      ici_run "$1" _sub_shell "$script"
+    fi
   fi
 }
 

--- a/industrial_ci/src/util.sh
+++ b/industrial_ci/src/util.sh
@@ -79,8 +79,8 @@ function ici_hook() {
 
   local script=${!name}
   if [ -n "$script" ]; then
-    if [ "${script%% *}" == "source" ]; then
-      ici_run "$1" eval "$script"
+    if [ "${script%% *}" == "sourcefile" ]; then
+      ici_run "$1" eval source "${script#sourcefile}"
     else
       ici_run "$1" _sub_shell "$script"
     fi


### PR DESCRIPTION
Fixes https://github.com/ros-industrial/industrial_ci/issues/519

This seems to work how I would expect and presents a pass-through like interface to bash if you put the word `source` at the beginning of your BEFORE_ / AFTER_ hook.

Example:
```AFTER_INIT="source /opt/intel/openvino/bin/setupvars.sh"```

If we do it this way I don't think we need extra documentation because it will run any script you pass it in a subshell but if you ask it to source something you don't want that in a subshell.  This intuitively makes the BEFORE_/AFTER_ variables work with this use-case.