### PR TITLE
use --force option on vcs import

### DIFF
--- a/industrial_ci/src/workspace.sh
+++ b/industrial_ci/src/workspace.sh
@@ -93,7 +93,7 @@ function ici_setup_git_client {
 }
 
 function ici_vcs_import {
-    vcs import --recursive "$@"
+    vcs import --recursive --force "$@"
 }
 
 function ici_import_repository {


### PR DESCRIPTION
This would enable me to change things in my .rosinstall files (like to point to a PR branch) without having to delete my docker image when I'm using `rerun_ci`.