### PR TITLE
discard HEAD version in vcs import

### DIFF
--- a/industrial_ci/src/workspace.sh
+++ b/industrial_ci/src/workspace.sh
@@ -111,7 +111,11 @@ function ici_import_repository {
         *)
             ;;
     esac
-    ici_vcs_import "$sourcespace" <<< "{repositories: {'${parts[0]}': {type: '${parts[1]}', url: '${parts[2]}', version: '${parts[3]}'}}}"
+    if [ "${parts[3]}" = "HEAD" ]; then
+        ici_vcs_import "$sourcespace" <<< "{repositories: {'${parts[0]}': {type: '${parts[1]}', url: '${parts[2]}'}}}"
+    else
+        ici_vcs_import "$sourcespace" <<< "{repositories: {'${parts[0]}': {type: '${parts[1]}', url: '${parts[2]}', version: '${parts[3]}'}}}"
+    fi
 }
 
 function ici_import_file {


### PR DESCRIPTION
`HEAD` version is not a valid input for vcs anymore (https://github.com/dirk-thomas/vcstool/pull/147).
This fixes the ABI check failures.