### PR TITLE
Github Action add cron for master branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * *" # every day at midnight
 
 jobs:
   shellcheck:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on: 
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   shellcheck:


### PR DESCRIPTION
Signed-off-by: Chen Bainian <brian97cbn@gmail.com>
Add cron job for master branch only (default branch) every day on UTC 00:00.
Will rebase this once the shellcheck error is fixed.
