### PR TITLE
Update libseccomp2 to fix statx syscall error

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -27,7 +27,7 @@ export PYTHONUNBUFFERED=${PYTHONUNBUFFERED:1}
 export _FOLDING_TYPE=travis
 
 # Update libseccomp to allow statx syscalls
-(sudo apt update && sudo apt install -y libseccomp2) &> "$(mktemp)"
+sudo apt-get update -qq && sudo apt-get install -y -qq libseccomp2
 
 if [ "$ABICHECK_MERGE" = "auto" ]; then
   export ABICHECK_MERGE=false

--- a/travis.sh
+++ b/travis.sh
@@ -26,6 +26,9 @@ export TARGET_REPO_NAME=${TRAVIS_REPO_SLUG##*/}
 export PYTHONUNBUFFERED=${PYTHONUNBUFFERED:1}
 export _FOLDING_TYPE=travis
 
+# Update libseccomp to allow statx syscalls
+(sudo apt update && sudo apt install -y libseccomp2) &> "$(mktemp)"
+
 if [ "$ABICHECK_MERGE" = "auto" ]; then
   export ABICHECK_MERGE=false
   [ "$TRAVIS_PULL_REQUEST" = "false" ] || ABICHECK_MERGE=true

--- a/travis.sh
+++ b/travis.sh
@@ -26,7 +26,7 @@ export TARGET_REPO_NAME=${TRAVIS_REPO_SLUG##*/}
 export PYTHONUNBUFFERED=${PYTHONUNBUFFERED:1}
 export _FOLDING_TYPE=travis
 
-# Update libseccomp to allow statx syscalls
+# Update libseccomp to allow statx syscalls (https://travis-ci.community/t/docker-build-environments/7216/4)
 sudo apt-get update -qq && sudo apt-get install -y -qq libseccomp2
 
 if [ "$ABICHECK_MERGE" = "auto" ]; then


### PR DESCRIPTION
Signed-off-by: Chen Bainian <brian97cbn@gmail.com>
Fix #542 
This problem has been bugging me for some time since the foxy-nightly docker
This fix will update libseccomp2 to higher than 2.3.3.
This will enable the docker-ce 18.06.0 run in Travis CI to allow statx syscall, which will fix the Qt5 RCC not found error in Foxy.
Reference: https://travis-ci.community/t/docker-build-environments/7216/4