### PR TITLE
checkout the latest code after importing

### DIFF
--- a/industrial_ci/src/workspace.sh
+++ b/industrial_ci/src/workspace.sh
@@ -94,6 +94,7 @@ function ici_setup_git_client {
 
 function ici_vcs_import {
     vcs import --recursive --force "$@"
+    vcs pull "$@"
 }
 
 function ici_import_repository {


### PR DESCRIPTION
Fixes  #550

I'm not sure if I like this solution or how well it'll work with non-git repos.  You'd think that `repo pull` would be all you really need but that will always fail when you have a git commit hash as your version in your rosinstall or repo file.  See this issue: https://github.com/dirk-thomas/vcstool/issues/165

I've tested this locally and it fixes my issue with vcs import for reusing docker containers.