### PR TITLE
Add option to disable running industrial_ci in a docker image

### DIFF
--- a/industrial_ci/src/tests/source_tests.sh
+++ b/industrial_ci/src/tests/source_tests.sh
@@ -101,7 +101,7 @@ function run_source_tests {
     # shellcheck disable=SC1090
     source "${ICI_SRC_PATH}/builders/$BUILDER.sh" || ici_error "Builder '$BUILDER' not supported"
 
-    if [ -z "$DO_NOT_RUN_IN_DOCKER" ]; then
+    if [ -z "$DISABLE_DOCKER_FOR_SOURCE_TESTS" ]; then
         ici_require_run_in_docker # this script must be run in docker
     fi
     upstream_ws=~/upstream_ws

--- a/industrial_ci/src/tests/source_tests.sh
+++ b/industrial_ci/src/tests/source_tests.sh
@@ -101,7 +101,9 @@ function run_source_tests {
     # shellcheck disable=SC1090
     source "${ICI_SRC_PATH}/builders/$BUILDER.sh" || ici_error "Builder '$BUILDER' not supported"
 
-    ici_require_run_in_docker # this script must be run in docker
+    if [ -z "$DO_NOT_RUN_IN_DOCKER" ]; then
+        ici_require_run_in_docker # this script must be run in docker
+    fi
     upstream_ws=~/upstream_ws
     target_ws=~/target_ws
     downstream_ws=~/downstream_ws


### PR DESCRIPTION
This might sound strange at first sight, but sometimes there's no need to run the whole build in a docker container spawned by `industrial_ci` itself. This is because many pipelines already run inside a docker container which is configurable by the user.

Also, there's another, technical reason, related to bitbucket pipelines: In pipelines when run as a docker service (i.e. docker inside docker), the support for ccache doesn't work because it is not possible to mount a pipeline build cache from outside the repository clone directory into the `industrial_ci` docker container. This is because security restrictions in pipelines prevent this: it is only possible to mount anything into a docker container from inside the `$BITBUCKET_CLONE_DIR`, but that is already mounted read-only in `industrial_ci`.

Hope the explanation is clear, I'm curious if this option would make sense to be merged.

