### PR TITLE
Remove docker pull tests on Gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,29 +33,3 @@ melodic:
   variables:
     ROS_DISTRO: "melodic"
     PRERELEASE: "true"
-
-# some internal tests
-
-docker_pull_base:
-  script:
-    - docker pull ubuntu:xenial
-    - docker tag ubuntu:xenial industrial-ci/ubuntu:xenial
-    - .industrial_ci/gitlab.sh ROS_DISTRO=kinetic DOCKER_BASE_IMAGE="industrial-ci/ubuntu:xenial" EXPECT_EXIT_CODE=1
-
-docker_no_pull_base:
-  script:
-    - docker pull ubuntu:xenial
-    - docker tag ubuntu:xenial industrial-ci/ubuntu:xenial
-    - .industrial_ci/gitlab.sh ROS_DISTRO=kinetic DOCKER_BASE_IMAGE="industrial-ci/ubuntu:xenial" DOCKER_PULL=false
-
-docker_pull:
-  script:
-    - docker pull rosindustrial/ci:kinetic-xenial-shadow-fixed
-    - docker tag rosindustrial/ci:kinetic-xenial-shadow-fixed industrial-ci/ubuntu:xenial
-    - .industrial_ci/gitlab.sh ROS_DISTRO=kinetic DOCKER_IMAGE="industrial-ci/ubuntu:xenial" EXPECT_EXIT_CODE=1
-
-docker_no_pull:
-  script:
-    - docker pull rosindustrial/ci:kinetic-xenial-shadow-fixed
-    - docker tag rosindustrial/ci:kinetic-xenial-shadow-fixed industrial-ci/ubuntu:xenial
-    - .industrial_ci/gitlab.sh ROS_DISTRO=kinetic DOCKER_IMAGE="industrial-ci/ubuntu:xenial" DOCKER_PULL=false


### PR DESCRIPTION
rosindustrial/ci:kinetic-xenial-shadow-fixed was removed

Passed: https://gitlab.com/ipa-mdl/industrial_ci/-/pipelines/249284727