### PR TITLE
also install osrf-pycommon for catkin_tools builder

### DIFF
--- a/industrial_ci/src/builders/catkin_tools.sh
+++ b/industrial_ci/src/builders/catkin_tools.sh
@@ -27,7 +27,7 @@ function _append_job_opts() {
 }
 
 function builder_setup {
-  ici_install_pkgs_for_command catkin "${PYTHON_VERSION_NAME}-catkin-tools" "ros-$ROS_DISTRO-catkin"
+  ici_install_pkgs_for_command catkin "${PYTHON_VERSION_NAME}-catkin-tools" "ros-$ROS_DISTRO-catkin" "${PYTHON_VERSION_NAME}-osrf-pycommon"
 }
 
 function builder_run_build {


### PR DESCRIPTION
ref https://github.com/ros-industrial/industrial_ci/issues/624#issuecomment-779354666
`BUILDER=catkin_tools` does not work for `noetic`:
```
Starting function 'build_upstream_workspace'
Traceback (most recent call last):
  File "/usr/bin/catkin", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 3254, in <module>
    def _initialize_master_working_set():
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 3237, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 3266, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 584, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 901, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 787, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'osrf-pycommon>0.1.1' distribution was not found and is required by catkin-tools
```
this is mentioned as workaround in multiple issues/posts