### PR TITLE
Always copy TARGET_REPO_PATH if it contains BASEDIR

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,7 +82,7 @@ test_junit_docker:
 
 test_junit_shell:
   image: ros:noetic
-  script: ./gitlab.sh TARGET_WORKSPACE="gh:ros/filters.git#HEAD"
+  script: ./gitlab.sh TARGET_WORKSPACE=". gh:ros/filters.git#HEAD"
   before_script: []
   services: []
   variables:

--- a/industrial_ci/src/ci_main.sh
+++ b/industrial_ci/src/ci_main.sh
@@ -41,6 +41,12 @@ source "${ICI_SRC_PATH}/ros.sh"
 
 trap ici_exit EXIT # install industrial_ci exit handler
 
+if [ -n "${BASEDIR:-}" ]; then
+  if [[ $(readlink -m "$BASEDIR")/ ==  $(readlink -m "$TARGET_REPO_PATH")/* ]]; then
+    ici_relocate_target_path
+  fi
+fi
+
 export ISOLATION=${ISOLATION:-docker}
 if [ "${CI:-}" != true ] ; then
   if [ "${ISOLATION}" = "shell" ]; then

--- a/industrial_ci/src/isolation/docker.sh
+++ b/industrial_ci/src/isolation/docker.sh
@@ -83,16 +83,6 @@ function ici_isolate() {
       unset ROS_DISTRO
   fi
 
-  if [ -n "${BASEDIR:-}" ]; then
-      # $BASEDIR is most-likely contained in $TARGET_REPO_PATH
-      # copy target repo to temporary folder first
-      local tmp_src
-      ici_make_temp_dir tmp_src
-      cp -a "$TARGET_REPO_PATH" "$tmp_src/"
-      export TARGET_REPO_PATH;
-      TARGET_REPO_PATH="$tmp_src/$(basename "$TARGET_REPO_PATH")"
-  fi
-
   ici_forward_mount TARGET_REPO_PATH ro
   ici_forward_mount ICI_SRC_PATH ro
   ici_forward_mount BASEDIR rw

--- a/industrial_ci/src/util.sh
+++ b/industrial_ci/src/util.sh
@@ -418,6 +418,13 @@ function ici_make_temp_dir {
   ici_cleanup_later "$ici_make_temp_dir_res"
 }
 
-# shellcheck disable=SC1090
+function ici_relocate_target_path {
+  local tmp_src
+  ici_make_temp_dir tmp_src
+  cp -a "$TARGET_REPO_PATH" "$tmp_src/"
+  export TARGET_REPO_PATH
+  TARGET_REPO_PATH="$tmp_src/$(basename "$TARGET_REPO_PATH")"
+}
 
+# shellcheck disable=SC1090
 ici_source_component _FOLDING_TYPE folding


### PR DESCRIPTION
As reported in https://github.com/ros-industrial/industrial_ci/pull/595#issuecomment-779171664
This paths creates the temporary folder, if BASEDIR is a sub-directory of TARGET_REPO_PATH or if they are equal.
Gitlab CI passed: https://gitlab.com/ipa-mdl/industrial_ci/-/pipelines/257815706

@stertingen: please have a look