### PR TITLE
Isolate install space with catkin_tools

### DIFF
--- a/industrial_ci/src/builders/catkin_tools.sh
+++ b/industrial_ci/src/builders/catkin_tools.sh
@@ -30,6 +30,12 @@ function builder_setup {
   ici_install_pkgs_for_command catkin "${PYTHON_VERSION_NAME}-catkin-tools" "ros-$ROS_DISTRO-catkin" "${PYTHON_VERSION_NAME}-osrf-pycommon"
 }
 
+function _catkin_config {
+    local extend=$1; shift
+    local ws=$1; shift
+    ici_exec_in_workspace "$extend" "$ws" catkin config --install
+}
+
 function builder_run_build {
     local extend=$1; shift
     local ws=$1; shift
@@ -38,7 +44,7 @@ function builder_run_build {
         opts+=("-vi")
     fi
     _append_job_opts opts PARALLEL_BUILDS 0
-    ici_exec_in_workspace "$extend" "$ws" catkin config --install
+    _catkin_config "$extend" "$ws"
     ici_exec_in_workspace "$extend" "$ws" catkin build "${opts[@]}" --summarize  --no-status "$@"
 }
 
@@ -47,10 +53,10 @@ function builder_run_tests {
     local ws=$1; shift
     local opts=()
     if [ "${VERBOSE_TESTS:-false}" != false ]; then
-        opts+=(-v)	
-    fi	
-    if [ "$IMMEDIATE_TEST_OUTPUT" == true ]; then	
-        opts+=(-i)	
+        opts+=(-v)
+    fi
+    if [ "$IMMEDIATE_TEST_OUTPUT" == true ]; then
+        opts+=(-i)
     fi
     _append_job_opts opts PARALLEL_TESTS 1
     ici_exec_in_workspace "$extend" "$ws" catkin build --catkin-make-args run_tests -- "${opts[@]}" --no-status

--- a/industrial_ci/src/builders/catkin_tools_isolated.sh
+++ b/industrial_ci/src/builders/catkin_tools_isolated.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Copyright (c) 2021, Mathias Lüdtke
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# shellcheck source=industrial_ci/src/builders/catkin_tools.sh
+source "${ICI_SRC_PATH}/builders/catkin_tools"
+
+function _catkin_config {
+    local extend=$1; shift
+    local ws=$1; shift
+    ici_exec_in_workspace "$extend" "$ws" catkin config --install --isolate-install --isolate-devel
+}


### PR DESCRIPTION
The resulting install space structure should be similar to colcon's.
This could be useful for detecting missing dependencies between packages.

Not sure, if we should provide an opt-out or if users should better fix their broken dependencies.