### PR TITLE
Resolve all symbolic links before starting ci_main.sh from run_ci

### DIFF
--- a/industrial_ci/scripts/run_ci
+++ b/industrial_ci/scripts/run_ci
@@ -42,7 +42,7 @@ else
     ci_dir=$(python2 -c "import rospkg; print rospkg.RosPack().get_path('industrial_ci')" 2>/dev/null) || { echo "could not find ci_main.sh"; exit 1; }
 fi
 
-env "$@" /bin/bash "$ci_dir/src/ci_main.sh"
+env "$@" /bin/bash "$(readlink -e "$ci_dir/src/ci_main.sh")"
 ret=$?
 
 if [ "$ret" == "0" ]; then


### PR DESCRIPTION
closes #642 

The issue with `--symlink-install` is that the files are linked individually, but the installed `src` folder actually exists.
This fix changes to real `src` first.

@tylerjw: please test
