### PR TITLE
unify test parameters

### DIFF
--- a/industrial_ci/mockups/failing_test/test/no_talker.test
+++ b/industrial_ci/mockups/failing_test/test/no_talker.test
@@ -1,11 +1,11 @@
 <launch>
   <!-- This launch file is used to test the rostest on CI server works. It can be any ROS tests that are generic enough -->
 
-  <param name="hztest1/topic" value="chatter" />
-  <param name="hztest1/hz" value="10.0" />
-  <param name="hztest1/hzerror" value="0.5" />
-  <param name="hztest1/test_duration" value="1.0" />
-  <param name="hztest1/wait_time" value="1.0" />
-  <test test-name="hztest_test" pkg="rostest" type="hztest"
-        name="hztest1" />
+  <test test-name="hztest_test" pkg="rostest" type="hztest" name="hztest1">
+    <param name="topic" value="chatter" />
+    <param name="hz" value="10.0" />
+    <param name="hzerror" value="0.5" />
+    <param name="test_duration" value="5.0" />
+    <param name="wait_time" value="5.0" />
+  </test>
 </launch>

--- a/industrial_ci/mockups/industrial_ci_testpkg/test/example_ros.test
+++ b/industrial_ci/mockups/industrial_ci_testpkg/test/example_ros.test
@@ -3,11 +3,11 @@
 
   <node name="talker" pkg="rospy_tutorials" type="talker.py" />
 
-  <param name="hztest1/topic" value="chatter" />  
-  <param name="hztest1/hz" value="10.0" />
-  <param name="hztest1/hzerror" value="0.5" />
-  <param name="hztest1/test_duration" value="5.0" />    
-  <param name="hztest1/wait_time" value="21.0" />    
-  <test test-name="hztest_test" pkg="rostest" type="hztest"
-        name="hztest1" />
+  <test test-name="hztest_test" pkg="rostest" type="hztest" name="hztest1">
+    <param name="topic" value="chatter" />
+    <param name="hz" value="10.0" />
+    <param name="hzerror" value="0.5" />
+    <param name="test_duration" value="5.0" />
+    <param name="wait_time" value="5.0" />
+  </test>
 </launch>


### PR DESCRIPTION
Simplify `.test` files listing ROS params as part of the `<test>` tag.