### PR TITLE
unittest for passing of CXXFLAGS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,12 @@ jobs:
           - {ROS_DISTRO: foxy}
           - {ROS_DISTRO: rolling}
 
+          # Are CXXFLAGS correctly passed? These tests should fail due to -Werror (exit code is for catkin tools: 1 and for colcon: 2)
+          - {ROS_DISTRO: melodic, CXXFLAGS: "-Werror", EXPECT_EXIT_CODE: 1, TARGET_WORKSPACE: 'industrial_ci/mockups/industrial_ci_testpkg'}
+          - {ROS_DISTRO: noetic, CXXFLAGS: "-Werror", EXPECT_EXIT_CODE: 2, TARGET_WORKSPACE: 'industrial_ci/mockups/industrial_ci_testpkg'}
+          - {ROS_DISTRO: melodic, CMAKE_ARGS: -DCMAKE_CXX_FLAGS="-Werror", EXPECT_EXIT_CODE: 1, TARGET_WORKSPACE: 'industrial_ci/mockups/industrial_ci_testpkg'}
+          - {ROS_DISTRO: noetic, CMAKE_ARGS: -DCMAKE_CXX_FLAGS="-Werror", EXPECT_EXIT_CODE: 2, TARGET_WORKSPACE: 'industrial_ci/mockups/industrial_ci_testpkg'}
+
           - {ROS_DISTRO: melodic}
           - {ROS_DISTRO: melodic, ROS_REPO: main}
 

--- a/industrial_ci/mockups/industrial_ci_testpkg/CMakeLists.txt
+++ b/industrial_ci/mockups/industrial_ci_testpkg/CMakeLists.txt
@@ -13,6 +13,10 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
+add_library(${PROJECT_NAME}
+  src/test_compiler.cpp
+)
+
 if (CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
   add_rostest(test/example_ros.test)

--- a/industrial_ci/mockups/industrial_ci_testpkg/src/test_compiler.cpp
+++ b/industrial_ci/mockups/industrial_ci_testpkg/src/test_compiler.cpp
@@ -1,0 +1,1 @@
+#warning "Create compiler warning"


### PR DESCRIPTION
I had a lot of trouble understanding, why my [rviz build didn't fail although I see compiler warnings](https://github.com/rhaschke/rviz/runs/2316648441) and have `-Werror` configured.
First I thought, `CXXFLAGS` are not correctly passed to the `BUILDER`. However, these tests prove that this works ok.
But, it looks like `CXXFLAGS` are not automatically passed to the child build job triggered for `python_qt_bindings` / `sip`.

Maybe, it's helpful to keep these tests anyway.