### PR TITLE
Don't run (failing!) cron-job workflow on a fork

### DIFF
--- a/.github/workflows/legacy.yml
+++ b/.github/workflows/legacy.yml
@@ -7,6 +7,7 @@ on:
 # https://stackoverflow.com/questions/58798886/github-actions-schedule-operation-on-branch
 jobs:
   shellcheck:
+    if: github.repository == ‘ros-industrial/industrial_ci’ # don't run on forks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -16,6 +17,7 @@ jobs:
         with:
           args: /bin/sh -c "shellcheck -x *.sh industrial_ci/scripts/*_ci industrial_ci/src/*.sh industrial_ci/src/*/*.sh"
   industrial_ci:
+    if: github.repository == ‘ros-industrial/industrial_ci’ # don't run on forks
     strategy:
       matrix:
         env:


### PR DESCRIPTION
Why do you need a scheduled workflows at all? Each push is validated anyway. Scheduled workflows only make sense if you depend on external resources, so maybe `external.yml` but not main?
The core issue is of course is that [we cannot opt-in or opt-out to GHA on forks](https://github.community/t/stop-github-actions-running-on-a-fork/17965/4).