### PR TITLE
run_clang_tidy: fix changed-files filter

### DIFF
--- a/industrial_ci/src/tests/source_tests.sh
+++ b/industrial_ci/src/tests/source_tests.sh
@@ -48,7 +48,7 @@ function run_clang_tidy {
         pushd "$src_dir" > /dev/null || true
         if git fetch -q origin "$CLANG_TIDY_BASE_REF" 2> /dev/null; then  # git might fail, e.g. operating on catkin_tools_prebuild
             # Filter for changed files, using sed to augment full path again (which git strips away)
-            mapfile -t files < <(git diff --name-only --diff-filter=MA FETCH_HEAD..HEAD -- "${files[@]}" | sed "s#^#$PWD/#")
+            mapfile -t files < <(git diff --name-only --diff-filter=MA FETCH_HEAD..HEAD -- "${files[@]}" | sed "s#^#$(git rev-parse --show-toplevel)/#")
         fi
         popd > /dev/null || true
     fi

--- a/industrial_ci/src/tests/source_tests.sh
+++ b/industrial_ci/src/tests/source_tests.sh
@@ -40,7 +40,7 @@ function run_clang_tidy {
     # create an array of all files listed in $db filtered by the source tree
     mapfile -t files < <(grep -oP "(?<=\"file\": \")($regex)(?=\")" "$db")
     local num_all_files="${#files[@]}"
-    if [ -n "$CLANG_TIDY_BASE_REF" ] ; then
+    if [ "$num_all_files" -gt 0 ] && [ -n "$CLANG_TIDY_BASE_REF" ] ; then
         echo "Filtering for files that actually changed since $CLANG_TIDY_BASE_REF"
         # Need to run git in actual source dir:  $files[@] refer to source dir and $PWD is read-only
         local src_dir
@@ -73,7 +73,7 @@ rm -rf "\$fixes"
 EOF
     chmod +x "$db.command"
 
-    echo "run clang-tidy for ${#files[@]} file(s) in $max_jobs process(es)."
+    echo "run clang-tidy for ${#files[@]}/$num_all_files file(s) in $max_jobs process(es)."
 
     printf "%s\0" "${files[@]}" | xargs --null -P "$max_jobs" -n "$(( (${#files[@]} + max_jobs-1) / max_jobs))" "$db.command" "$@"
     cat /tmp/clang_tidy_output.* | grep -vP "^([0-9]+ warnings generated|Use .* to display errors from system headers as well)\.$" || true


### PR DESCRIPTION
Fixup a bug introduced in #655: non-cpp files might get clang-tidy checked:
https://github.com/ros-planning/moveit_task_constructor/runs/2423567108

If no source files are found in `compile_commands.json`, the subsequent git filtering just returns *all* changed files. 
However these shouldn't be clang-tidy checked!