### PR TITLE
Test that UNDERLAY contains a setup.bash

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -212,7 +212,7 @@ Note that some of these currently tied only to a single option, but we still lea
 * **PYLINT_EXCLUDE** (default: not set): can be used to exclude files via the ``-not -path`` filter
 * **TARGET_CMAKE_ARGS** (default: not set): Addtional CMake arguments for target `workspace <#workspace-management>`__.
 * **TARGET_WORKSPACE** (default: ``$TARGET_REPO_PATH``): Definition of sources for target `workspace <#workspace-management>`__.
-* **UNDERLAY** (default: ``/opt/ros/$ROS_DISTRO``): Path to a workspace to be used as an underlay of the workspaces being set up be ICI, e.g. a workspace provided by a custom docker image
+* **UNDERLAY** (default: not set): Path to an install space (instead of ``/opt/ros/$ROS_DISTRO``) to be used as an underlay of the workspaces being set up be ICI, e.g. a workspace provided by a custom docker image
 * **UPSTREAM_CMAKE_ARGS** (default: not set): Addtional CMake arguments for upstream `workspace <#workspace-management>`__.
 * **UPSTREAM_WORKSPACE** (default: not set): Definition of upstream `workspace <#workspace-management>`__.
 * **VERBOSE_OUTPUT** (default: ``false``): If ``true``, build tool (e.g. Catkin) output prints in verbose mode.

--- a/industrial_ci/src/run.sh
+++ b/industrial_ci/src/run.sh
@@ -62,7 +62,7 @@ ici_run "init" ici_init_apt
 
 if [ -n "${UNDERLAY:-}" ]; then
     if [ ! -f "$UNDERLAY/setup.bash" ]; then
-        ici_error "UNDERLAY '$UNDERLAY'  does not contain a setup.bash"
+        ici_error "UNDERLAY '$UNDERLAY' does not contain a setup.bash"
     fi
 else
     if [ -n "${ROS_DISTRO:-}" ]; then

--- a/industrial_ci/src/run.sh
+++ b/industrial_ci/src/run.sh
@@ -42,10 +42,6 @@ if [ "$DEBUG_BASH" = true ]; then set -x; fi # print trace if DEBUG
 
 ici_configure_ros
 
-if [ -n "${ROS_DISTRO:-}" ]; then
-    export UNDERLAY=${UNDERLAY:-/opt/ros/$ROS_DISTRO}
-fi
-
 export TARGET_WORKSPACE=${TARGET_WORKSPACE:-$TARGET_REPO_PATH}
 export BASEDIR=${BASEDIR:-$HOME}
 
@@ -63,6 +59,16 @@ TEST=$1; shift
 ici_source_component TEST tests
 
 ici_run "init" ici_init_apt
+
+if [ -n "${UNDERLAY:-}" ]; then
+    if [ ! -f "$UNDERLAY/setup.bash" ]; then
+        ici_error "UNDERLAY '$UNDERLAY'  does not contain a setup.bash"
+    fi
+else
+    if [ -n "${ROS_DISTRO:-}" ]; then
+        export UNDERLAY=${UNDERLAY:-/opt/ros/$ROS_DISTRO}
+    fi
+fi
 
 "$@"
 


### PR DESCRIPTION
This tests `UNDERLAY` to prevent from issues like #668.
The test was moved after the init script to allow for underlays created in a script.

Setting `UNDERLAY=/opt/ros/$ROS_DISTRO` will only work if a ROS-based Docker images is used.

@fmessmer, @tylerjw, @JStech : Please test