### PR TITLE
Add instruction for custom root certificate

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -721,6 +721,13 @@ Note for rerun_ci limitations
 
 If you are using this feature to have a cached way to run ci locally you probably want your dependencies to be updated just as they are when run on a remote ci service.  To achieve this you can cause the target workspace to be pulled by adding this argument: ``AFTER_SETUP_TARGET_WORKSPACE='vcs pull ~/target_ws/src/'``.
 
+Run locally with custom root certificate
+++++++++++++++++++++++++++++++++++++++++
+If a custom root ssl certificate needs to be used this can be done by passing the local certificate to the container using
+::
+
+  $ rosrun industrial_ci run_ci ROS_DISTRO=noetic ROS_REPO=main DOCKER_RUN_OPTS="-v /usr/local/share/ca-certificates:/usr/local/share/ca-certificates:ro"
+
 For maintainers of industrial_ci repository
 ================================================
 


### PR DESCRIPTION
Add section to doc describing how to run industrial_ci locally if a root certificate needs to be used.

I am aware of `DOCKER_RUN_OPTS="-v /etc/ssl/certs:/etc/ssl/certs:ro"` also mentioned in the Readme.
This however did not work for me since the certificate installation on the local machine would fail during the
**init**-step with

```
Setting up ca-certificates (20210119~20.04.1) ...
Updating certificates in /etc/ssl/certs...
rm: cannot remove 'ca-certificates.crt': Read-only file system
dpkg: error processing package ca-certificates (--configure):
 installed ca-certificates package post-installation script subprocess returned error exit status 1

...
Errors were encountered while processing:
 ca-certificates
E: Sub-process /usr/bin/dpkg returned an error code (1)
<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
'init' returned with code '100' after 1 min 19 sec
Tests failed exit code '100'
```
this seems to be due to the existing `ca-certificates.crt` which originates from the installation of the certificate on the local system.

Not sure if to many have this problem but I think it is worth writing down the solution.

Open for suggestions / better solutions!
