### PR TITLE
Remove hydro test from legacy cron job

### DIFF
--- a/.github/workflows/legacy.yml
+++ b/.github/workflows/legacy.yml
@@ -25,7 +25,6 @@ jobs:
           - {ROS_DISTRO: melodic, PRERELEASE: true}
           - {ROS_DISTRO: kinetic, ROS_REPO: ros}
           - {ROS_DISTRO: melodic, ROS_REPO: ros}
-          - {ROS_DISTRO: hydro}
           - {ROS_DISTRO: indigo}
           - {ROS_DISTRO: jade}
           - {ROS_DISTRO: kinetic}


### PR DESCRIPTION
The Ubuntu archive repository does not host the packages for precise anymore.