### PR TITLE
Make catkin_tools the default builder for ROS1 noetic

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,9 +60,10 @@ jobs:
 
           # Are CXXFLAGS correctly passed? These tests should fail due to -Werror (exit code is for catkin tools: 1 and for colcon: 2)
           - {ROS_DISTRO: melodic, CXXFLAGS: "-Werror", EXPECT_EXIT_CODE: 1, TARGET_WORKSPACE: 'industrial_ci/mockups/industrial_ci_testpkg'}
-          - {ROS_DISTRO: noetic, CXXFLAGS: "-Werror", EXPECT_EXIT_CODE: 2, TARGET_WORKSPACE: 'industrial_ci/mockups/industrial_ci_testpkg'}
+          - {ROS_DISTRO: noetic, CXXFLAGS: "-Werror", EXPECT_EXIT_CODE: 1, TARGET_WORKSPACE: 'industrial_ci/mockups/industrial_ci_testpkg'}
           - {ROS_DISTRO: melodic, CMAKE_ARGS: -DCMAKE_CXX_FLAGS="-Werror", EXPECT_EXIT_CODE: 1, TARGET_WORKSPACE: 'industrial_ci/mockups/industrial_ci_testpkg'}
-          - {ROS_DISTRO: noetic, CMAKE_ARGS: -DCMAKE_CXX_FLAGS="-Werror", EXPECT_EXIT_CODE: 2, TARGET_WORKSPACE: 'industrial_ci/mockups/industrial_ci_testpkg'}
+          - {ROS_DISTRO: noetic, CMAKE_ARGS: -DCMAKE_CXX_FLAGS="-Werror", EXPECT_EXIT_CODE: 1, TARGET_WORKSPACE: 'industrial_ci/mockups/industrial_ci_testpkg'}
+          - {ROS_DISTRO: noetic, BUILDER: colcon, CMAKE_ARGS: -DCMAKE_CXX_FLAGS="-Werror", EXPECT_EXIT_CODE: 2, TARGET_WORKSPACE: 'industrial_ci/mockups/industrial_ci_testpkg'}
 
           - {ROS_DISTRO: melodic}
           - {ROS_DISTRO: melodic, ROS_REPO: main}

--- a/industrial_ci/src/ros.sh
+++ b/industrial_ci/src/ros.sh
@@ -56,7 +56,6 @@ function _set_ros_defaults {
         _ros1_defaults "bionic"
         ;;
     "noetic")
-        export BUILDER=${BUILDER:-colcon}
         _ros1_defaults "focal"
         export ROS_PYTHON_VERSION=3
         ;;


### PR DESCRIPTION
While I would like to use colcon for ROS1 as well, it has several issues.
I hope that this will not break too many builds.
`BUILDER=colcon` is still supported, but now as an opt-in.

closes #629 and closes #666

@wxmerkt: Please test, if this resolves your build issues.