### PR TITLE
Fix clang-tidy checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,8 +75,9 @@ jobs:
           - {ROS_DISTRO: kinetic, TARGET_WORKSPACE: 'industrial_ci/mockups/format_tests/cpp/LLVM', CLANG_FORMAT_CHECK: 'WebKit', EXPECT_EXIT_CODE: 1}
 
           # Tidy
-          - {ROS_DISTRO: melodic, TARGET_WORKSPACE: 'industrial_ci/mockups/test_clang_tidy', CLANG_TIDY: pedantic}
-          - {ROS_DISTRO: melodic, TARGET_WORKSPACE: 'industrial_ci/mockups/test_clang_tidy', CLANG_TIDY: pedantic, CLANG_TIDY_ARGS: "-checks=modernize-use-nullptr", EXPECT_EXIT_CODE: 1}
+          - {ROS_DISTRO: noetic, TARGET_WORKSPACE: 'industrial_ci/mockups/test_clang_tidy', CLANG_TIDY: true}
+          - {ROS_DISTRO: melodic, TARGET_WORKSPACE: 'industrial_ci/mockups/test_clang_tidy', CLANG_TIDY: pedantic, EXPECT_EXIT_CODE: 1}
+          - {ROS_DISTRO: melodic, TARGET_WORKSPACE: 'industrial_ci/mockups/test_clang_tidy', CLANG_TIDY: pedantic, CLANG_TIDY_ARGS: "-checks=-*,modernize-use-nullptr", EXPECT_EXIT_CODE: 1}
 
 
     runs-on: ubuntu-latest

--- a/industrial_ci/mockups/test_clang_tidy/.clang-tidy
+++ b/industrial_ci/mockups/test_clang_tidy/.clang-tidy
@@ -1,0 +1,6 @@
+Checks:          '-*,
+                  readability-identifier-naming,
+                 '
+CheckOptions:
+  - key:             readability-identifier-naming.VariableCase
+    value:           UPPER_CASE

--- a/industrial_ci/src/tests/source_tests.sh
+++ b/industrial_ci/src/tests/source_tests.sh
@@ -67,7 +67,7 @@ function run_clang_tidy {
     cat > "$db.command" << EOF
 #!/bin/bash
 fixes=\$(mktemp)
-clang-tidy "-export-fixes=\$fixes" "-header-filter=$regex" "-p=$build" "\$@" &> /tmp/clang_tidy_output.\$\$ 2>&1 || { touch "$db.error"; echo "Errored for '\$*'"; }
+clang-tidy "-export-fixes=\$fixes" "-header-filter=$regex" "-p=$build" "\$@" &> /tmp/clang_tidy_output.\$\$ 2>&1 || { touch "$db.error"; }
 if [ -s "\$fixes" ]; then touch "$db.warn"; fi
 rm -rf "\$fixes"
 EOF

--- a/industrial_ci/src/tests/source_tests.sh
+++ b/industrial_ci/src/tests/source_tests.sh
@@ -102,6 +102,7 @@ function run_clang_tidy_check {
         ici_setup_git_client
     fi
 
+    pushd "$TARGET_REPO_PATH" > /dev/null || exit  # Run in TARGET_REPO_PATH
     ici_hook "before_clang_tidy_checks"
 
     while read -r db; do
@@ -109,6 +110,7 @@ function run_clang_tidy_check {
     done < <(find "$target_ws/build" -mindepth 2 -name compile_commands.json)  # -mindepth 2, because colcon puts a compile_commands.json into the build folder
 
     ici_hook "after_clang_tidy_checks"
+    popd > /dev/null || exit
 
     if [ "${#warnings[@]}" -gt "0" ]; then
         ici_warn "Clang tidy warning(s) in: ${warnings[*]}"

--- a/industrial_ci/src/tests/source_tests.sh
+++ b/industrial_ci/src/tests/source_tests.sh
@@ -102,9 +102,13 @@ function run_clang_tidy_check {
         ici_setup_git_client
     fi
 
+    ici_hook "before_clang_tidy_checks"
+
     while read -r db; do
         run_clang_tidy "$target_ws/src" warnings errors "$db" "${clang_tidy_args[@]}"
     done < <(find "$target_ws/build" -mindepth 2 -name compile_commands.json)  # -mindepth 2, because colcon puts a compile_commands.json into the build folder
+
+    ici_hook "after_clang_tidy_checks"
 
     if [ "${#warnings[@]}" -gt "0" ]; then
         ici_warn "Clang tidy warning(s) in: ${warnings[*]}"


### PR DESCRIPTION
`clang-tidy` checks ignored existing `.clang-tidy` config files, because clang-tidy was run from `target_ws`.
Now instead, clang-tidy is run from the folder of each individual source file separately. A corresponding unit test is added. Additionally, I enabled hooks `BEFORE_CLANG_TIDY_CHECKS` and `AFTER_CLANG_TIDY_CHECKS`. These could be used to e.g. show the list of applied checks etc. They are applied _once_ before/after all clang-tidy checks in the `target_ws`.