### PR TITLE
Require ROS_VERSION during build of industrial_ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,6 +131,7 @@ jobs:
           - {ROS_DISTRO: noetic, UBUNTU: 20.04}
           - {ROS_DISTRO: noetic, PRERELEASE: true, UBUNTU: 20.04}
           - {ROS_DISTRO: foxy, UBUNTU: 20.04}
+          - {ROS_DISTRO: galactic, PRERELEASE: true, UBUNTU: 20.04}
     runs-on: ubuntu-${{matrix.env.UBUNTU}}
     steps:
       - uses: actions/checkout@v1

--- a/industrial_ci/CMakeLists.txt
+++ b/industrial_ci/CMakeLists.txt
@@ -10,13 +10,15 @@ if("$ENV{ROS_VERSION}" EQUAL "2")
     set(${PROJECT_NAME}_BIN_DESTINATION lib/${PROJECT_NAME})
     set(${PROJECT_NAME}_SHARE_DESTINATION share/${PROJECT_NAME})
     install(PROGRAMS scripts/run_travis DESTINATION ${${PROJECT_NAME}_BIN_DESTINATION})
-else()
+elseif("$ENV{ROS_VERSION}" EQUAL "1")
     find_package(catkin REQUIRED)
     catkin_package()
 
     set(${PROJECT_NAME}_BIN_DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
     set(${PROJECT_NAME}_SHARE_DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
     catkin_install_python(PROGRAMS scripts/run_travis DESTINATION ${${PROJECT_NAME}_BIN_DESTINATION})
+else()
+    message(FATAL_ERROR "ROS_VERSION is neither 1 nor 2")
 endif()
 
 install(PROGRAMS scripts/run_ci scripts/rerun_ci

--- a/industrial_ci/package.xml
+++ b/industrial_ci/package.xml
@@ -21,15 +21,16 @@
   <url type="repository">https://github.com/ros-industrial/industrial_ci</url>
   <url type="bugtracker">https://github.com/ros-industrial/industrial_ci/issues</url>
 
-  <buildtool_depend condition="$ROS_VERSION != 2">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
   <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
+  <buildtool_depend>ros_environment</buildtool_depend>
 
   <exec_depend>coreutils</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION != 3">python-yaml</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-yaml</exec_depend>
 
   <export>
-      <build_type condition="$ROS_VERSION != 2">catkin</build_type>
+      <build_type condition="$ROS_VERSION == 1">catkin</build_type>
       <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
   </export>
 </package>


### PR DESCRIPTION
Fixes ROS2 pre-release of industrial_ci, does not fallback to catkin anymore.