### PR TITLE
Remove isolated test job for kinetic

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,7 +127,6 @@ jobs:
     strategy:
       matrix:
         env:
-          - {ROS_DISTRO: kinetic, UBUNTU: 16.04}
           - {ROS_DISTRO: melodic, UBUNTU: 18.04}
           - {ROS_DISTRO: noetic, UBUNTU: 20.04}
           - {ROS_DISTRO: noetic, PRERELEASE: true, UBUNTU: 20.04}


### PR DESCRIPTION
ubuntu-16.04 environment is deprecated (https://github.com/actions/virtual-environments/issues/3287)