### PR TITLE
Test run_travis for ROS2 foxy instead of rolling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,9 +55,9 @@ jobs:
           - {ROS_DISTRO: noetic, TARGET_WORKSPACE: 'industrial_ci/mockups/industrial_ci_testpkg'}
           - {ROS_DISTRO: noetic, PRERELEASE: true}
           - {ROS_DISTRO: noetic, AFTER_SCRIPT: 'rosenv rosrun industrial_ci run_travis', ADDITIONAL_DEBS: "ros-noetic-rosbash"}
-          - {ROS_DISTRO: foxy}
+          - {ROS_DISTRO: foxy, AFTER_SCRIPT: 'rosenv ros2 run industrial_ci run_travis', ADDITIONAL_DEBS: "ros-foxy-ros2run"}
           - {ROS_DISTRO: galactic}
-          - {ROS_DISTRO: rolling, AFTER_SCRIPT: 'rosenv ros2 run industrial_ci run_travis', ADDITIONAL_DEBS: "ros-rolling-ros2run"}
+          - {ROS_DISTRO: rolling}
 
           # Are CXXFLAGS correctly passed? These tests should fail due to -Werror (exit code is for catkin tools: 1 and for colcon: 2)
           - {ROS_DISTRO: melodic, CXXFLAGS: "-Werror", EXPECT_EXIT_CODE: 1, TARGET_WORKSPACE: 'industrial_ci/mockups/industrial_ci_testpkg'}


### PR DESCRIPTION
Fixes the (temporary) test failures.