### PR TITLE
added special workspace setup for just one repo

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -314,6 +314,11 @@ Or mixed:
 
   DOWNSTREAM_WORKSPACE="github:ros-simulation/gazebo_ros_pkgs@melodic-devel https://raw.githubusercontent.com/ros-controls/ros_control/melodic-devel/ros_control.rosinstall -ros_control additional.repos"
 
+To depend on a different repository of a private server using git and the SSH protocol:
+::
+
+  UPSTREAM_WORKSPACE='git+ssh://git@private.server.net/repository#branch'
+
 To filter the target workspace:
 ::
 

--- a/industrial_ci/src/workspace.sh
+++ b/industrial_ci/src/workspace.sh
@@ -37,7 +37,7 @@ function ici_parse_repository_url {
             gitlab | gl)
                 echo "${name%.git}" "git" "https://gitlab.com/$repo" "$fragment"
                 ;;
-            'git+file'*|'git+http'*)
+            'git+file'*|'git+http'*|'git+ssh'*)
                 echo "${name%.git}" "git" "${scheme#git+}:$repo" "$fragment"
                 ;;
             git+*)


### PR DESCRIPTION
Hello, 

I added this parsing command for url, if you just want to workspace extend with one private repo using ssh without creating a ".repos" or ".rosinstall" file (very niche case I guess).

Maybe there was already a way to achieve that but as I couldn't, I added this 'git+ssh'.

Does it make sense ?

Thank you !

