### PR TITLE
Fix tiny typo in doc

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -312,7 +312,7 @@ Or mixed:
 
 ::
 
-  DOWNSTREAM_WORKSPACE="github:ros-simulation/gazebo_ros_pkgs@melodic-devel https://raw.githubusercontent.com/ros-controls/ros_control/melodic-devel/ros_control.rosinstall -ros_control additional.repos"
+  DOWNSTREAM_WORKSPACE="github:ros-simulation/gazebo_ros_pkgs#melodic-devel https://raw.githubusercontent.com/ros-controls/ros_control/melodic-devel/ros_control.rosinstall -ros_control additional.repos"
 
 To depend on a different repository of a private server using git and the SSH protocol:
 ::


### PR DESCRIPTION
Branch name needs to be separated by `#` not `@`.