### PR TITLE
catkin_tools_devel.sh: drop --install flag

### DIFF
--- a/industrial_ci/src/builders/catkin_tools_devel.sh
+++ b/industrial_ci/src/builders/catkin_tools_devel.sh
@@ -23,3 +23,9 @@ ici_warn "BUILDER=catkin_tools_devel should only be used in addition to the othe
 function ici_extend_space {
     echo "$1/devel"
 }
+
+function _catkin_config {
+    local extend=$1; shift
+    local ws=$1; shift
+    ici_exec_in_workspace "$extend" "$ws" catkin config --init
+}


### PR DESCRIPTION
I need to come back to https://github.com/ros-industrial/industrial_ci/pull/707/files#r673922264. Unfortunately, using a linked devel-space layout is not compatible with the `--install` flag: https://github.com/catkin/catkin_tools/issues/674#issuecomment-879008090.

Sourcing `devel/setup.bash` [doesn't yield the correct `ROS_PACKAGE_PATH`](https://github.com/ros-planning/moveit/runs/4130420882?check_suite_focus=true#step:5:315) (not including the sourced workspace), such that `find_package(catkin ...)` yields wrong results. Dropping the `--install` flag, everything [works as expected](https://github.com/ros-planning/moveit/runs/4130667967?check_suite_focus=true).
