### PR TITLE
Fix folder removal

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -272,6 +272,7 @@ Each workspace can be composed as a sequence of the following items:
 * relative path of a ``*.repos`` or ``*.rosinstall`` file
 * (relative) directory path to a source directory
 * directory path prefixed with ``-`` to remove the directory, as a path relative to either the source space or the target repository
+* directory path prefixed with ``+`` to move a directory (relative to last imported repository) to the main source space
 * ``.`` to copy the full target repository
 
 For backwards compatibility, ``UPSTREAM_WORKSPACE`` can be set to ``debian`` and ``file`` as well, but not in combination with the other options and with a deprecation warning.

--- a/industrial_ci/src/workspace.sh
+++ b/industrial_ci/src/workspace.sh
@@ -296,6 +296,13 @@ function ici_prepare_sourcespace {
             ici_log "Removing '${sourcespace:?}/$file'"
             ici_guard rm -r "${sourcespace:?}/$file"
             ;;
+        +*)
+            for file in "${source:1}" "$last/${source:1}"; do
+                if [ -e "${sourcespace:?}/$file" ]; then break; fi
+            done
+            ici_log "Moving '${sourcespace:?}/$file' to '${sourcespace:?}'"
+            ici_guard mv "${sourcespace:?}/$file" "${sourcespace:?}"
+            ;;
         .)
             ici_log "Copying '$basepath'"
             ici_import_directory "$sourcespace" "$basepath"


### PR DESCRIPTION
Trying to keep a single folder from a larger source repository, I ran into several issues:
1. It's not easy to keep a single folder, but delete all others
2. Deleting folders as [described in the docs](https://github.com/ros-industrial/industrial_ci/blob/master/doc/index.rst#examples) [doesn't work](https://github.com/rhaschke/test/runs/4654230318):
`UPSTREAM_WORKSPACE='github:ros-controls/ros_control#melodic-devel -rqt_controller_manager'`
The folder should be specified with the repository prefix: `-ros_control/rqt_controller_manager`. However, this is clumsy.

This PR
1. remembers the last imported repository name
2. tries to delete a folder from that repo (thus matching the docs)
3. adds syntax `+folder` to keep a specific folder

Example run: https://github.com/rhaschke/test/runs/4654479819