### PR TITLE
[`abi_check`] Pass quoted `cflags` to colcon

### DIFF
--- a/industrial_ci/src/tests/abi_check.sh
+++ b/industrial_ci/src/tests/abi_check.sh
@@ -81,7 +81,7 @@ function abi_process_workspace() {
   local version=${1:-$tag}
 
   local cflags="-g -Og"
-  local cmake_args=(--cmake-args "-DCMAKE_C_FLAGS=$cflags" "-DCMAKE_CXX_FLAGS=$cflags")
+  local cmake_args=(--cmake-args "-DCMAKE_C_FLAGS=\"$cflags\"" "-DCMAKE_CXX_FLAGS=\"$cflags\"")
 
   ici_step "install_${tag}_dependencies" ici_install_dependencies "$extend" "$ROSDEP_SKIP_KEYS" "$workspace/src"
   ici_step "abi_build_${tag}" builder_run_build "$extend" "$workspace" "${cmake_args[@]}"


### PR DESCRIPTION
The `colcon` invocation in `abi_process_workspace` was only providing
the first of the two `cflags`, hence omitting `-Og`. To work around
this, the flags must be enclosed by literal quotation marks.

This commit escapes the flag specification to insert these literal
quotes around the flags.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>
