### PR TITLE
Add humble to the supported distros

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
           - {ROS_DISTRO: noetic, AFTER_SCRIPT: 'rosenv rosrun industrial_ci run_travis', ADDITIONAL_DEBS: "ros-noetic-rosbash"}
           - {ROS_DISTRO: foxy, AFTER_SCRIPT: 'rosenv ros2 run industrial_ci run_travis', ADDITIONAL_DEBS: "ros-foxy-ros2run"}
           - {ROS_DISTRO: galactic, TRACE: true}
-          - {ROS_DISTRO: humble, ROS_REPO: testing}
+          - {ROS_DISTRO: humble}
           - {ROS_DISTRO: rolling}
 
           # Are CXXFLAGS correctly passed? These tests should fail due to -Werror (exit code is for catkin tools: 1 and for colcon: 2)
@@ -242,7 +242,7 @@ jobs:
           
           - repo: 'ros-controls/control_msgs'
             ref: 'galactic-devel'
-            env: {ROS_DISTRO: humble, PRERELEASE: true, ROS_REPO: testing}
+            env: {ROS_DISTRO: humble, PRERELEASE: true}
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -239,6 +239,10 @@ jobs:
           - repo: 'ros-controls/control_msgs'
             ref: 'galactic-devel'
             env: {ROS_DISTRO: galactic, PRERELEASE: true}
+          
+          - repo: 'ros-controls/control_msgs'
+            ref: 'galactic-devel'
+            env: {ROS_DISTRO: humble, PRERELEASE: true, ROS_REPO: testing}
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,7 @@ jobs:
           - {ROS_DISTRO: noetic, AFTER_SCRIPT: 'rosenv rosrun industrial_ci run_travis', ADDITIONAL_DEBS: "ros-noetic-rosbash"}
           - {ROS_DISTRO: foxy, AFTER_SCRIPT: 'rosenv ros2 run industrial_ci run_travis', ADDITIONAL_DEBS: "ros-foxy-ros2run"}
           - {ROS_DISTRO: galactic, TRACE: true}
+          - {ROS_DISTRO: humble, ROS_REPO: testing}
           - {ROS_DISTRO: rolling}
 
           # Are CXXFLAGS correctly passed? These tests should fail due to -Werror (exit code is for catkin tools: 1 and for colcon: 2)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -38,6 +38,7 @@ The following `ROS <http://wiki.ros.org/Distributions>`__ / `ROS2 <https://index
 * `Eloquent <https://index.ros.org/doc/ros2/Releases/Release-Eloquent-Elusor/>`__ *(EOL)*
 * `Foxy <https://index.ros.org/doc/ros2/Releases/Release-Foxy-Fitzroy/>`__
 * `Galactic <https://docs.ros.org/en/foxy/Releases/Release-Galactic-Geochelone.html>`__
+* `Humble <https://docs.ros.org/en/humble/Releases/Release-Humble-Hawksbill.html>`__
 * `Rolling <https://index.ros.org/doc/ros2/Releases/Release-Rolling-Ridley/>`__
 
 Supported CIs

--- a/industrial_ci/src/ros.sh
+++ b/industrial_ci/src/ros.sh
@@ -80,6 +80,9 @@ function _set_ros_defaults {
     "galactic")
         _ros2_defaults "focal"
         ;;
+    "humble")
+        _ros2_defaults "jammy"
+        ;;
     "rolling")
         _ros2_defaults "jammy"
         ;;


### PR DESCRIPTION
We should add humble to the supported distros. 
I think this will do it but I still need to test.