### PR TITLE
catkin tools should call `catkin test` for testing

### DIFF
--- a/industrial_ci/src/builders/catkin_tools.sh
+++ b/industrial_ci/src/builders/catkin_tools.sh
@@ -59,7 +59,7 @@ function builder_run_tests {
         opts+=(-i)
     fi
     _append_job_opts opts PARALLEL_TESTS 1
-    ici_cmd ici_exec_in_workspace "$extend" "$ws" catkin build --catkin-make-args run_tests -- "${opts[@]}" --no-status
+    ici_cmd ici_exec_in_workspace "$extend" "$ws" catkin test "${opts[@]}" --no-status
 }
 
 function builder_test_results {

--- a/industrial_ci/src/builders/catkin_tools.sh
+++ b/industrial_ci/src/builders/catkin_tools.sh
@@ -59,7 +59,7 @@ function builder_run_tests {
         opts+=(-i)
     fi
     _append_job_opts opts PARALLEL_TESTS 1
-    ici_cmd ici_exec_in_workspace "$extend" "$ws" catkin test "${opts[@]}" --no-status
+    ici_cmd ici_exec_in_workspace "$extend" "$ws" catkin run_tests "${opts[@]}" --no-status
 }
 
 function builder_test_results {


### PR DESCRIPTION
Calling `catkin build --catkin-make-args run_tests` is only correct for catkin packages, not for pure cmake packages, which require  `catkin build --catkin-make-args test`. `catkin test` selects the correct build target automatically:
https://catkin-tools.readthedocs.io/en/latest/verbs/catkin_test.html?highlight=run_tests#basic-usage