### PR TITLE
Fix GHA warnings

### DIFF
--- a/.github/workflows/legacy.yml
+++ b/.github/workflows/legacy.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.repository == 'ros-industrial/industrial_ci' # don't run on forks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
           ref: legacy
       - uses: docker://koalaman/shellcheck-alpine
@@ -31,7 +31,7 @@ jobs:
           - {ROS_DISTRO: melodic}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
           ref: legacy
       - run: ./ci.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: docker://koalaman/shellcheck-alpine
         with:
           args: /bin/sh -c "shellcheck -x *.sh industrial_ci/scripts/*_ci industrial_ci/src/*.sh industrial_ci/src/*/*.sh"
@@ -94,7 +94,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: './'
         with:
           config: ${{toJSON(matrix)}}
@@ -108,7 +108,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: './'
         id: ici
         with:
@@ -139,13 +139,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout external repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{matrix.repo}}
           ref: ${{matrix.ref}}
           fetch-depth: ${{matrix.depth}}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: .industrial_ci
 
@@ -167,14 +167,14 @@ jobs:
           - {ROS_DISTRO: galactic, PRERELEASE: true, UBUNTU: 20.04, TARGET_WORKSPACE: ". github:ros-controls/control_msgs#galactic-devel"}
     runs-on: ubuntu-${{matrix.env.UBUNTU}}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: './'
         env: ${{matrix.env}}
 
   builders:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - run: |
           for BUILDER in $(ls industrial_ci/src/builders/*.sh); do
             echo "##[group]BUILDER=$BUILDER"
@@ -185,7 +185,7 @@ jobs:
   test_arm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: docker/setup-qemu-action@v1
       - uses: './'
         env:
@@ -196,7 +196,7 @@ jobs:
   run_travis:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - run: |
           sudo apt install -y python-yaml
           industrial_ci/scripts/run_travis
@@ -247,13 +247,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout external repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{matrix.repo}}
           ref: ${{matrix.ref}}
           fetch-depth: ${{matrix.depth}}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: .industrial_ci
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: docker://koalaman/shellcheck-alpine
         with:
           args: /bin/sh -c "shellcheck -x *.sh industrial_ci/scripts/*_ci industrial_ci/src/*.sh industrial_ci/src/*/*.sh"
-  industrial_ci:
+  ici:
     env:
       TRACE: true
     strategy:
@@ -203,7 +203,7 @@ jobs:
           python2 industrial_ci/scripts/run_travis
           industrial_ci/scripts/run_travis 1
 
-  industrial_ci_external:
+  ici_ext:
     strategy:
       fail-fast: false
       matrix:
@@ -239,7 +239,7 @@ jobs:
           - repo: 'ros-controls/control_msgs'
             ref: 'galactic-devel'
             env: {ROS_DISTRO: galactic, PRERELEASE: true}
-          
+
           - repo: 'ros-controls/control_msgs'
             ref: 'galactic-devel'
             env: {ROS_DISTRO: humble, PRERELEASE: true}

--- a/README.rst
+++ b/README.rst
@@ -141,7 +141,7 @@ For GitHub Actions
              - {ROS_DISTRO: melodic, ROS_REPO: main}
        runs-on: ubuntu-latest
        steps:
-         - uses: actions/checkout@v1
+         - uses: actions/checkout@v3
          - uses: 'ros-industrial/industrial_ci@master'
            env: ${{matrix.env}}
 

--- a/doc/industrial_ci_action.yml
+++ b/doc/industrial_ci_action.yml
@@ -28,7 +28,7 @@ jobs:
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache" # directory for ccache (and how we enable ccache in industrial_ci)
     steps:
-      - uses: actions/checkout@v2 # clone target repository
+      - uses: actions/checkout@v3 # clone target repository
       - uses: actions/cache@v2 # fetch/store the directory used by ccache before/after the ci run
         with:
           path: ${{ env.CCACHE_DIR }}


### PR DESCRIPTION
Fix warnings about deprecated node.js 12 actions. Updates to latest versions.
Also shorten CI job names to better see the actual job description