### PR TITLE
Improve clang-tidy check

### DIFF
--- a/industrial_ci/src/tests/merge_fixes.py
+++ b/industrial_ci/src/tests/merge_fixes.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2022, Robert Haschke
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import yaml
+import sys
+
+
+def merge_fixes(files):
+   """Merge all fixes files into mergefile"""
+   # The fixes suggested by clang-tidy >= 4.0.0 are given under
+   # the top level key 'Diagnostics' in the output yaml files
+   mergefile = files[0]
+   mergekey = "Diagnostics"
+   merged = []
+   for file in files:
+      try:
+         with open(file, 'r') as inp:
+            content = yaml.safe_load(inp)
+            if not content:
+               continue  # Skip empty files.
+            merged.extend(content.get(mergekey, []))
+      except FileNotFoundError:
+         pass
+
+   with open(mergefile, 'w') as out:
+      if merged:
+         # Assemble output dict with MainSourceFile=''.
+         output = {'MainSourceFile': '', mergekey: merged}
+         yaml.safe_dump(output, out)
+
+
+if __name__ == "__main__":
+   merge_fixes(sys.argv[1:])

--- a/industrial_ci/src/tests/merge_fixes.py
+++ b/industrial_ci/src/tests/merge_fixes.py
@@ -20,6 +20,13 @@ import yaml
 import sys
 
 
+def key(item):
+   name = item.get("DiagnosticName")
+   msg = item.get("DiagnosticMessage")
+   file = msg.get("FilePath")
+   offset = msg.get("FileOffset")
+   return name, file, offset
+
 def merge_fixes(files):
    """Merge all fixes files into mergefile"""
    # The fixes suggested by clang-tidy >= 4.0.0 are given under
@@ -27,13 +34,22 @@ def merge_fixes(files):
    mergefile = files[0]
    mergekey = "Diagnostics"
    merged = []
+   seen = set()  # efficiently remember fixes already inserted
+
+   def have(x):
+      k = key(x)
+      return k in seen or seen.add(k)
+
+   def unique(seq):
+      return [x for x in seq if not have(x)]
+
    for file in files:
       try:
          with open(file, 'r') as inp:
             content = yaml.safe_load(inp)
             if not content:
                continue  # Skip empty files.
-            merged.extend(content.get(mergekey, []))
+            merged.extend(unique(content.get(mergekey, [])))
       except FileNotFoundError:
          pass
 

--- a/industrial_ci/src/tests/source_tests.sh
+++ b/industrial_ci/src/tests/source_tests.sh
@@ -112,6 +112,10 @@ function run_clang_tidy_check {
         fi
     done < <(find "$target_ws/build" -mindepth 2 -name compile_commands.json)  # -mindepth 2, because colcon puts a compile_commands.json into the build folder
 
+    if [ -n "${fixes_final}" ]; then
+        # translate file names in fixes file
+        sed -i "s#$target_ws/src/$TARGET_REPO_NAME/#$TARGET_REPO_PATH/#g" "${fixes_final}"
+    fi
     ici_hook "after_clang_tidy_checks"
 
     if [ "${#warnings[@]}" -gt "0" ]; then

--- a/industrial_ci/src/tests/source_tests.sh
+++ b/industrial_ci/src/tests/source_tests.sh
@@ -66,7 +66,7 @@ function run_clang_tidy {
     local err=0
     ici_log "run clang-tidy for ${#files[@]}/$num_all_files file(s) in $max_jobs process(es)."
     set -o pipefail
-    printf "%s\0" "${files[@]}" | xargs --null run-clang-tidy "-j$max_jobs" "-header-filter=$regex" "-p=$build" "$@" 2>&1 | tee "$db.tidy.log" || err=$?
+    printf "%s\0" "${files[@]}" | xargs --null run-clang-tidy "-j$max_jobs" "-header-filter=\"$regex\"" "-p=$build" "$@" 2>&1 | tee "$db.tidy.log" || err=$?
     set +o pipefail
 
     if [ "$err" -ne "0" ]; then

--- a/industrial_ci/src/tests/source_tests.sh
+++ b/industrial_ci/src/tests/source_tests.sh
@@ -65,7 +65,9 @@ function run_clang_tidy {
 
     local err=0
     ici_log "run clang-tidy for ${#files[@]}/$num_all_files file(s) in $max_jobs process(es)."
+    set -o pipefail
     printf "%s\0" "${files[@]}" | xargs --null run-clang-tidy "-j$max_jobs" "-header-filter=$regex" "-p=$build" "$@" 2>&1 | tee "$db.tidy.log" || err=$?
+    set +o pipefail
 
     if [ "$err" -ne "0" ]; then
        _run_clang_tidy_errors+=("$name")

--- a/industrial_ci/src/tests/source_tests.sh
+++ b/industrial_ci/src/tests/source_tests.sh
@@ -65,12 +65,12 @@ function run_clang_tidy {
 
     local err=0
     ici_log "run clang-tidy for ${#files[@]}/$num_all_files file(s) in $max_jobs process(es)."
-    printf "%s\0" "${files[@]}" | xargs --null run-clang-tidy "-j$max_jobs" "-header-filter=$regex" "-p=$build" "$@" | tee "$db.tidy.log" || err=$?
+    printf "%s\0" "${files[@]}" | xargs --null run-clang-tidy "-j$max_jobs" "-header-filter=$regex" "-p=$build" "$@" 2>&1 | tee "$db.tidy.log" || err=$?
 
     if [ "$err" -ne "0" ]; then
        _run_clang_tidy_errors+=("$name")
        ici_time_end "${ANSI_RED}" "$err"
-    elif grep -q ": warning: " "$db.tidy.log"; then
+    elif grep -q "warning: " "$db.tidy.log"; then
         _run_clang_tidy_warnings+=("$name")
         ici_time_end "${ANSI_YELLOW}"
     else


### PR DESCRIPTION
Partially fixes #796:
- Don't `-export-fixes` by default
- Use `run-clang-tidy` instead of `clang-tidy` to (hopefully) better handle parallel changes to the same files
  Unfortunately, this changes cmdline API, i.e. options have different names!

TODO: Handle fixes from multiple packages:
- [x] parse `clang_tidy_args` for `-export-fixes <filename>`, replace filename with some temporary file
- [x] run-clang-tidy, writing fixes to this temporary file
- [x] merge yaml files into the final one:
      https://stackoverflow.com/questions/25630633/merging-yaml-config-files-recursively-with-bash
      https://mikefarah.gitbook.io/yq/v/v3.x/commands/merge

There is an interesting github action, processing clang-tidy's fixes into PR comments:
https://github.com/marketplace/actions/pull-request-comments-from-clang-tidy-reports

I triggered a test build for MoveIt: https://github.com/ros-planning/moveit/pull/3250

@EzraBrooks, do you have resources to contribute?