### PR TITLE
run_ros_prerelease: drop builder_setup

### DIFF
--- a/industrial_ci/src/tests/ros_prerelease.sh
+++ b/industrial_ci/src/tests/ros_prerelease.sh
@@ -102,8 +102,6 @@ function prepare_ros_prerelease() {
 
 function run_ros_prerelease() {
     ici_source_builder
-    ici_step "${BUILDER}_setup" builder_setup
-
     ici_step "setup_ros_prerelease" setup_ros_prerelease
 
     # Environment vars.


### PR DESCRIPTION
The prerelease test always runs image `ros:noetic-ros-core`, independent of `ROS_DISTRO`:
https://github.com/ros-industrial/industrial_ci/blob/d4628964b237e878e4b585277aef1d720bd9c173/industrial_ci/src/tests/ros_prerelease.sh#L100

Subsequently running `${BUILDER}_setup` attempts to install the wrong debian package (matching `ROS_DISTRO`):
```
catkin_make_isolated_setup
  $ sudo apt-get -qq install -y --no-upgrade --no-install-recommends ros-melodic-catkin | grep -E 'Setting up' 
  E: Unable to locate package ros-melodic-catkin
```