### PR TITLE
Fix installation of dependencies

### DIFF
--- a/industrial_ci/src/tests/source_tests.sh
+++ b/industrial_ci/src/tests/source_tests.sh
@@ -173,10 +173,12 @@ function run_source_tests {
     ici_step "setup_rosdep" ici_setup_rosdep
 
     extend=${UNDERLAY:?}
+    export ROSDEP_SOURCE_FOLDERS=("${UNDERLAY:?}")  # source folders to be ignored for rosdep install
 
     if [ -n "$UPSTREAM_WORKSPACE" ]; then
         ici_with_ws "$upstream_ws" ici_build_workspace "upstream" "$extend" "$upstream_ws"
         extend="$(ici_extend_space "$upstream_ws")"
+        ROSDEP_SOURCE_FOLDERS+=("$extend")
     fi
 
     if [ "${CLANG_TIDY:-false}" != false ]; then
@@ -206,6 +208,7 @@ function run_source_tests {
     fi
 
     extend="$(ici_extend_space "$target_ws")"
+    ROSDEP_SOURCE_FOLDERS+=("$extend")
     if [ -n "$DOWNSTREAM_WORKSPACE" ]; then
         ici_with_ws "$downstream_ws" ici_build_workspace "downstream" "$extend" "$downstream_ws"
         #extend="$(ici_extend_space "$downstream_ws")"

--- a/industrial_ci/src/workspace.sh
+++ b/industrial_ci/src/workspace.sh
@@ -361,7 +361,7 @@ function ici_install_dependencies {
       cmake_prefix_path="$(ici_exec_in_workspace "$extend" . env | grep -oP '^CMAKE_PREFIX_PATH=\K.*'):" || true
     fi
 
-    rosdep_opts=(-q --from-paths "$@" "${UNDERLAY:?}" --ignore-src -y)
+    rosdep_opts=(-q --from-paths "$@" --ignore-src -y)
     if [ -n "$skip_keys" ]; then
       rosdep_opts+=(--skip-keys "$skip_keys")
     fi

--- a/industrial_ci/src/workspace.sh
+++ b/industrial_ci/src/workspace.sh
@@ -361,7 +361,7 @@ function ici_install_dependencies {
       cmake_prefix_path="$(ici_exec_in_workspace "$extend" . env | grep -oP '^CMAKE_PREFIX_PATH=\K.*'):" || true
     fi
 
-    rosdep_opts=(-q --from-paths "$@" --ignore-src -y)
+    rosdep_opts=(-q --from-paths "$@" "$extend" --ignore-src -y)
     if [ -n "$skip_keys" ]; then
       rosdep_opts+=(--skip-keys "$skip_keys")
     fi

--- a/industrial_ci/src/workspace.sh
+++ b/industrial_ci/src/workspace.sh
@@ -386,7 +386,7 @@ function ici_build_workspace {
     fi
 
     ici_step "setup_${name}_workspace" ici_prepare_sourcespace "$ws/src" "${sources[@]}"
-    ici_step "install_${name}_dependencies" ici_install_dependencies "$extend" "$ROSDEP_SKIP_KEYS" "$ws/src"
+    ici_step "install_${name}_dependencies" ici_install_dependencies "$extend" "$ROSDEP_SKIP_KEYS" "$ws/src" "${ROSDEP_SOURCE_FOLDERS[@]}"
     ici_step "build_${name}_workspace" builder_run_build "$extend" "$ws" "${args[@]}"
 }
 

--- a/industrial_ci/src/workspace.sh
+++ b/industrial_ci/src/workspace.sh
@@ -361,7 +361,7 @@ function ici_install_dependencies {
       cmake_prefix_path="$(ici_exec_in_workspace "$extend" . env | grep -oP '^CMAKE_PREFIX_PATH=\K.*'):" || true
     fi
 
-    rosdep_opts=(-q --from-paths "$@" "$extend" --ignore-src -y)
+    rosdep_opts=(-q --from-paths "$@" "${UNDERLAY:?}" --ignore-src -y)
     if [ -n "$skip_keys" ]; then
       rosdep_opts+=(--skip-keys "$skip_keys")
     fi


### PR DESCRIPTION
ici_install_dependencies shouldn't install dependencies that are available in an underlay. Usually, this is ensure by construction, starting from a clean /opt/ros and then installing dependencies for upstream, target, and downstream in turn. However, there is the `UNDERLAY` variable, which allows to use another underlay than /opt/ros. In that case, the underlay might provide packages, which would be required for install.

[Here](https://github.com/rhaschke/moveit_tutorials/actions/runs/4383973036/jobs/7674876282) is an example using `UNDERLAY=/root/ws_moveit/install` from a custom docker image. In that case, installation shouldn't care about `moveit-*` packages, [which didn't work before](https://github.com/rhaschke/moveit_tutorials/actions/runs/4382632515/jobs/7671900708).