### PR TITLE
Added support for iron irwini

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,7 @@ jobs:
           - {ROS_DISTRO: foxy, AFTER_SCRIPT: 'rosenv ros2 run industrial_ci run_travis', ADDITIONAL_DEBS: "ros-foxy-ros2run"}
           - {ROS_DISTRO: galactic, TRACE: true}
           - {ROS_DISTRO: humble}
+          - {ROS_DISTRO: iron}
           - {ROS_DISTRO: rolling}
 
           # Are CXXFLAGS correctly passed? These tests should fail due to -Werror (exit code is for catkin tools: 1 and for colcon: 2)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -39,6 +39,7 @@ The following `ROS <http://wiki.ros.org/Distributions>`__ / `ROS2 <https://index
 * `Foxy <https://index.ros.org/doc/ros2/Releases/Release-Foxy-Fitzroy/>`__
 * `Galactic <https://docs.ros.org/en/foxy/Releases/Release-Galactic-Geochelone.html>`__ *(EOL)*
 * `Humble <https://docs.ros.org/en/humble/Releases/Release-Humble-Hawksbill.html>`__
+* `Iron <https://docs.ros.org/en/rolling/Releases/Release-Iron-Irwini.html>`__
 * `Rolling <https://index.ros.org/doc/ros2/Releases/Release-Rolling-Ridley/>`__
 
 Supported CIs

--- a/industrial_ci/src/ros.sh
+++ b/industrial_ci/src/ros.sh
@@ -84,6 +84,9 @@ function _set_ros_defaults {
     "humble")
         _ros2_defaults "jammy"
         ;;
+    "iron")
+        _ros2_defaults "jammy"
+        ;;
     "rolling")
         _ros2_defaults "jammy"
         ;;


### PR DESCRIPTION
This PR should add support for the upcoming Iron Irwini release. Unfortunately, this currently fails, since with an installed iron sourcing `/opr/ros/iron/setup.bash` currently results in `$ROSDISTRO=rolling` and then `rosdep install` fails, since the rosdistro is [explicitly passed](https://github.com/ros-industrial/industrial_ci/blob/4b78602d67127a63dce62926769d9ec4e2ce72e4/industrial_ci/src/workspace.sh#L335) to `rosdep update`.

I guess this should be everything that needs to be adapted here, hence I'm opening this PR.