### PR TITLE
Use shallow import with VCS

### DIFF
--- a/industrial_ci/src/workspace.sh
+++ b/industrial_ci/src/workspace.sh
@@ -177,7 +177,7 @@ function ici_setup_git_client {
 }
 
 function ici_vcs_import {
-    ici_guard vcs import --recursive --force "$@"
+    ici_guard vcs import --recursive --force --shallow "$@"
 }
 
 function ici_import_repository {


### PR DESCRIPTION
Changes per commit message to reduce overall setup time (and resultant docker image size) when working with large projects.