### PR TITLE
Pin ROS2 rolling to 2024-02-28

### DIFF
--- a/industrial_ci/src/ros.sh
+++ b/industrial_ci/src/ros.sh
@@ -96,6 +96,7 @@ function _set_ros_defaults {
         ;;
     "rolling")
         _ros2_defaults "jammy"
+        export ROSDEP_SOURCES_VERSION=${ROSDEP_SOURCES_VERSION:-rolling/2024-02-28}
         ;;
     "false")
         unset ROS_DISTRO


### PR DESCRIPTION
Work-around for https://github.com/ros/rosdistro/pull/40033