### PR TITLE
Revert "Use building repo for rolling"

### DIFF
--- a/industrial_ci/src/ros.sh
+++ b/industrial_ci/src/ros.sh
@@ -96,7 +96,6 @@ function _set_ros_defaults {
         ;;
     "rolling")
         _ros2_defaults "noble"
-        _use_repo_or_final_snapshot "https://repo.ros2.org/ubuntu/building/"
         ;;
     "false")
         unset ROS_DISTRO


### PR DESCRIPTION
This reverts commit 6931750a64c88d171e23b5397c6c14231acc27cd.