### PR TITLE
Install llvm repository for newer versions of clang-format

### DIFF
--- a/industrial_ci/src/tests/clang_format_check.sh
+++ b/industrial_ci/src/tests/clang_format_check.sh
@@ -35,7 +35,7 @@ function run_clang_format_check() {
     ici_apt_install lsb-release software-properties-common gnupg
     ici_cmd wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
     ici_cmd chmod +x /tmp/llvm.sh
-    ici_cmd /tmp/llvm.sh "$CLANG_FORMAT_VERSION"
+    ici_cmd ici_asroot /tmp/llvm.sh "$CLANG_FORMAT_VERSION"
   fi
 
   ici_apt_install git-core "$clang_format_executable"

--- a/industrial_ci/src/tests/clang_format_check.sh
+++ b/industrial_ci/src/tests/clang_format_check.sh
@@ -28,6 +28,16 @@ function run_clang_format_check() {
   local clang_format_executable="clang-format${CLANG_FORMAT_VERSION:+-$CLANG_FORMAT_VERSION}"
 
   ici_time_start install_clang_format
+
+  # Install llvm repository to install the correct clang version if not supported by default on the distro
+  if ! apt-cache search --names-only "$clang_format_executable" | grep -q "clang"; then
+    ici_install_pkgs_for_command wget wget
+    ici_apt_install lsb-release software-properties-common gnupg
+    ici_cmd wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
+    ici_cmd chmod +x /tmp/llvm.sh
+    ici_cmd /tmp/llvm.sh "$CLANG_FORMAT_VERSION"
+  fi
+
   ici_apt_install git-core "$clang_format_executable"
   ici_time_end # install_clang_format
 


### PR DESCRIPTION
Using `CLANG_FORMAT_VERSION` we can specify which `clang-format` version to use. This assumes the version is available via apt.

I wanted to be able to use more recent versions of `clang-format` uniformly across multiple different ROS versions. Being limited to what is available for the base image is somewhat restrictive in this case. Furthermore, the packages that are included in Ubuntu are quite old.

The proposed changes check if the requested version is available via apt. If not, it will install the requested version using the _Automatic installation script_ recommended by https://apt.llvm.org/
