### PR TITLE
Move to ws folder for rosdep command, fixes #876

### DIFF
--- a/industrial_ci/src/workspace.sh
+++ b/industrial_ci/src/workspace.sh
@@ -373,7 +373,7 @@ function ici_install_dependencies {
       rosdep_opts+=(--skip-keys "$skip_keys")
     fi
 
-    ROS_PACKAGE_PATH="$cmake_prefix_path${ROS_PACKAGE_PATH:-}" ici_cmd ici_quiet ici_filter "(executing command)|(Setting up)" ici_exec_in_workspace "$extend" "." rosdep install "${rosdep_opts[@]}"
+    ROS_PACKAGE_PATH="$cmake_prefix_path${ROS_PACKAGE_PATH:-}" ici_cmd ici_quiet ici_filter "(executing command)|(Setting up)" ici_exec_in_workspace "$extend" "$@" rosdep install "${rosdep_opts[@]}"
 }
 
 function ici_build_workspace {


### PR DESCRIPTION
Executing the `rosdep` command from the root of the repository results in multiple packages found with the same name when run from the CI on GitLab. (See #876 for more information)

I have been unable to find the root cause for this, but this fix seems to circumvent the issue by restricting the folders `rosdep` can search in. I believe functionally this should behave the same. 