### PR TITLE
Install Python dependencies globally for Python > 3.10

### DIFF
--- a/industrial_ci/src/workspace.sh
+++ b/industrial_ci/src/workspace.sh
@@ -373,7 +373,13 @@ function ici_install_dependencies {
       rosdep_opts+=(--skip-keys "$skip_keys")
     fi
 
-    ROS_PACKAGE_PATH="$cmake_prefix_path${ROS_PACKAGE_PATH:-}" ici_cmd ici_quiet ici_filter "(executing command)|(Setting up)" ici_exec_in_workspace "$extend" "." PIP_BREAK_SYSTEM_PACKAGES=1 rosdep install "${rosdep_opts[@]}"
+    # rosdep needs to be able to install to the system packages directory for Python versions > 3.10
+    local p=$(python3 -c 'import sys; print(sys.version_info[0] > 2 and sys.version_info[1] > 10)'>&1) 
+    if [ $p == "True" ]; then
+      export PIP_BREAK_SYSTEM_PACKAGES=1
+    fi
+
+    ROS_PACKAGE_PATH="$cmake_prefix_path${ROS_PACKAGE_PATH:-}" ici_cmd ici_quiet ici_filter "(executing command)|(Setting up)" ici_exec_in_workspace "$extend" "." rosdep install "${rosdep_opts[@]}"
 }
 
 function ici_build_workspace {

--- a/industrial_ci/src/workspace.sh
+++ b/industrial_ci/src/workspace.sh
@@ -373,7 +373,7 @@ function ici_install_dependencies {
       rosdep_opts+=(--skip-keys "$skip_keys")
     fi
 
-    ROS_PACKAGE_PATH="$cmake_prefix_path${ROS_PACKAGE_PATH:-}" ici_cmd ici_quiet ici_filter "(executing command)|(Setting up)" ici_exec_in_workspace "$extend" "." rosdep install "${rosdep_opts[@]}"
+    ROS_PACKAGE_PATH="$cmake_prefix_path${ROS_PACKAGE_PATH:-}" ici_cmd ici_quiet ici_filter "(executing command)|(Setting up)" ici_exec_in_workspace "$extend" "." PIP_BREAK_SYSTEM_PACKAGES=1 rosdep install "${rosdep_opts[@]}"
 }
 
 function ici_build_workspace {


### PR DESCRIPTION
Pure python dependencies break with rosdep on Python versions newer than 3.10, which impacts ROS 2 Jazzy and Rolling. See the discussion below for details.

https://discourse.ros.org/t/rosdep-for-pip-is-broken-on-jazzy/38981/8
https://github.com/ros-infrastructure/rosdep/blob/f6857691e9a23e3a3f39e55189195dc3e4bf0770/doc/pip_and_pep_668.rst

This PR addresses the problem by setting the environment variable `PIP_BREAK_SYSTEM_PACKAGES` when the Python version is newer than 3.10. It resolves issue https://github.com/ros-industrial/industrial_ci/issues/881.