### PR TITLE
Implement ssh-key and ssh-known-hosts support for GHA

### DIFF
--- a/.github/action.sh
+++ b/.github/action.sh
@@ -48,4 +48,25 @@ if [ "${ACT:-}" = true ]; then
   ici_warn "Detected act, bundling industrial_ci"
 fi
 
+INPUT_SSH_KEY=$(printenv INPUT_SSH-KEY) || true
+INPUT_SSH_KNOWN_HOSTS=$(printenv INPUT_SSH-KNOWN-HOSTS) || true
+
+if [ -n "${INPUT_SSH_KEY:-}" ]; then
+  # start SSH agent
+  # shellcheck disable=SC2046
+  eval $(ssh-agent -s)
+  # add key to agent
+  ssh-add <(echo "$INPUT_SSH_KEY") || { res=$?; echo "could not add ssh key"; exit $res; }
+fi
+
+if [ -n "${SSH_AUTH_SOCK:-}" ]; then
+  # setup known hosts
+  mkdir -p ~/.ssh
+  if [ -n "${INPUT_SSH_KNOWN_HOSTS:-}" ]; then
+    echo "$INPUT_SSH_KNOWN_HOSTS" >> ~/.ssh/known_hosts
+  else
+    cat /etc/ssh/ssh_known_hosts >> ~/.ssh/known_hosts
+  fi
+fi
+
 env "$@" bash "$ICI_SRC_PATH/ci_main.sh"

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,12 @@ inputs:
   config:
     description: 'Configuration in JSON format, e.g. from matrix'
     required: false
+  ssh-key:
+    description: 'Entire content of your private SSH key file'
+    required: false
+  ssh-known-hosts:
+    description: 'Addtional entries for the host key database'
+    required: false
 runs:
   using: 'node20'
   main: '.github/action.js'


### PR DESCRIPTION
```yaml
test_ici:
    runs-on: ubuntu-latest
    steps:
      - uses: 'mathias-luedtke/industrial_ci@feature/github-ssh-key'
        with:
          ssh-key: ${{ secrets.private_key }}
        env:
          ROS_DISTRO: "humble"
          TARGET_WORKSPACE: "git+ssh://git@github.com/mathias-luedtke/testpriv.git#main"
```