### PR TITLE
Remove isolated tests for ubuntu-20.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -200,12 +200,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env:
-          - {ROS_DISTRO: noetic, UBUNTU: 20.04}
-          - {ROS_DISTRO: noetic, PRERELEASE: true, UBUNTU: 20.04}
-          - {ROS_DISTRO: noetic, UBUNTU: 20.04, TEST: debians, TARGET_WORKSPACE: ". industrial_ci/mockups/industrial_ci_testpkg"}
-          - {ROS_DISTRO: foxy, UBUNTU: 20.04}
+        env:  
+          - {ROS_DISTRO: humble, UBUNTU: 22.04}
+          - {ROS_DISTRO: humble, UBUNTU: 22.04, TEST: debians}
           - {ROS_DISTRO: humble, PRERELEASE: true, UBUNTU: 22.04, TARGET_WORKSPACE: ". github:ros-controls/control_msgs#galactic-devel"}
+          - {ROS_DISTRO: jazzy, UBUNTU: 24.04}
+          - {ROS_DISTRO: jazzy, UBUNTU: 24.04, TEST: debians}
+          - {ROS_DISTRO: jazzy, PRERELEASE: true, UBUNTU: 24.04, TARGET_WORKSPACE: ". github:ros-controls/control_msgs#galactic-devel"}
     runs-on: ubuntu-${{matrix.env.UBUNTU}}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
> This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
