### PR TITLE
Configure TLS for DinD on Gitlab.com

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@
 # For local runners you might want to enable the overlay driver:
 # https://docs.gitlab.com/ce/ci/docker/using_docker_build.html#using-the-overlayfs-driver
 
-image: docker:git # docker and git clients
+image: docker:24.0.5-git # docker and git clients
 
 # The docker runner does not expose /tmp to the docker-in-docker service
 # This config ensures that the temp folder is located inside the project directory (e.g. for prerelease tests or SSH agent forwarding)
@@ -17,7 +17,7 @@ cache:
 
 # enable docker-in-docker
 services:
-  - docker:20.10.16-dind
+  - docker:24.0.5-dind
 
 before_script:
   - apk add --update bash coreutils tar grep # install industrial_ci dependencies

--- a/industrial_ci/src/tests/ros_prerelease.sh
+++ b/industrial_ci/src/tests/ros_prerelease.sh
@@ -91,9 +91,21 @@ function prepare_ros_prerelease() {
 
     if [ -n "${DOCKER_PORT:-}" ]; then
         ici_forward_variable DOCKER_HOST "$DOCKER_PORT"
+    elif [ -n "${DOCKER_HOST:-}" ]; then
+        ici_forward_variable DOCKER_HOST
+        if [[ "$DOCKER_HOST" =~ ^tcp://docker: ]]; then
+            _docker_run_opts+=(--add-host docker=host-gateway)
+        fi
+        if [ -n "${DOCKER_CERT_PATH:-}" ]; then
+            ici_forward_mount DOCKER_CERT_PATH ro
+        fi
+        if [ -n "${DOCKER_TLS_VERIFY:-}" ]; then
+            ici_forward_variable DOCKER_TLS_VERIFY
+        fi
     elif [ -e /var/run/docker.sock ]; then
         ici_forward_mount /var/run/docker.sock rw
     fi
+
     if [ -n "${CCACHE_DIR}" ]; then
       ici_forward_mount CCACHE_DIR rw "$WORKSPACE/home/.ccache"
       CCACHE_DIR= # prevent cachedir from beeing added twice


### PR DESCRIPTION
Gitlab.com instance runners are enforcing TLS and dropped `DOCKER_PORT`.