### PR TITLE
Update Node version from 20 to 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,5 +6,5 @@ inputs:
     description: 'Configuration in JSON format, e.g. from matrix'
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: '.github/action.js'


### PR DESCRIPTION
Node.js 20 is deprecated now:

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

I'm getting this kind of warnings with my CI:

<img width="1409" height="127" alt="obrazek" src="https://github.com/user-attachments/assets/6c88a939-8ca6-4516-9b7f-043a4e32cbfc" />
